### PR TITLE
Feature/#28-개발 서버에 Rest Docs가 배포가 안되는 문제 해결

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build & Test
         run: |
-          ./gradlew build --daemon --parallel
+          ./gradlew clean build --daemon --parallel
           java -Djarmode=layertools -jar build/libs/doore-0.0.1-SNAPSHOT.jar extract
 
       - name: Compress

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build & Test
         run: |
-          ./gradlew clean build --daemon --parallel
+          ./gradlew build && ./gradlew build 
           java -Djarmode=layertools -jar build/libs/doore-0.0.1-SNAPSHOT.jar extract
 
       - name: Compress

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build & Test
         run: |
-          ./gradlew clean build
+          ./gradlew build --daemon --build-cache && ./gradlew build --daemon --build-cache
           java -Djarmode=layertools -jar build/libs/doore-0.0.1-SNAPSHOT.jar extract
 
       - name: Compress

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build & Test
         run: |
-          ./gradlew build && ./gradlew build 
+          ./gradlew clean build
           java -Djarmode=layertools -jar build/libs/doore-0.0.1-SNAPSHOT.jar extract
 
       - name: Compress

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build & Test
         run: |
-          ./gradlew build --daemon --build-cache --parallel
+          ./gradlew build --daemon --parallel
           java -Djarmode=layertools -jar build/libs/doore-0.0.1-SNAPSHOT.jar extract
 
       - name: Compress
@@ -94,9 +94,9 @@ jobs:
           key: ${{ secrets.SSH_KEY_DEV }}
           envs: GITHUB_SHA
           script: |
-              cd ~/01-doo-re-infrastructure/doo-re/deploy
-              chmod +x ./deploy_server.sh
-              sudo ./deploy_server.sh ${GITHUB_SHA::8} dev
+            cd ~/01-doo-re-infrastructure/doo-re/deploy
+            chmod +x ./deploy_server.sh
+            sudo ./deploy_server.sh ${GITHUB_SHA::8} dev
 
       - name: Notify Slack
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -23,22 +23,7 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.1'
-
-    //restdocs
-    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-}
-
+/******* Start Spring Rest Docs *******/
 ext {
     snippetsDir = file('build/generated-snippets')
 }
@@ -72,4 +57,22 @@ bootJar {
 
 build {
     dependsOn copyDocument
+}
+/******* End Spring Rest Docs *******/
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.1'
+
+    //restdocs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ tasks.register('copyDocument', Copy) {
 
 bootJar {
     dependsOn asciidoctor
-    from("${asciidoctor.outputDir}") {
+    from("${asciidoctor.outputDir}/html5") {
         into "static/docs"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,13 +33,18 @@ tasks.named('test') {
 }
 
 test {
+    useJUnitPlatform()
     outputs.dir snippetsDir
 }
 
 asciidoctor {
+    doFirst {
+        project.delete(files("src/main/resources/static/docs"))
+    }
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
     dependsOn test
+    baseDirFollowsSourceFile()
 }
 
 tasks.register('copyDocument', Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -57,10 +57,19 @@ asciidoctor {
     dependsOn test
 }
 
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from file("${asciidoctor.outputDir}")
+    into file("src/main/resources/static/docs")
+}
+
 bootJar {
     dependsOn asciidoctor
-    copy {
-        from("${asciidoctor.outputDir}")
-        into 'src/main/resources/static/docs'
+    from("${asciidoctor.outputDir}") {
+        into "static/docs"
     }
+}
+
+build {
+    dependsOn copyDocument
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

https://github.com/BDD-CLUB/01-doo-re-back/issues/28

## 📝 작업 내용

기존의 Gradle은 두레 프로젝트 내부의 src/main/resources/static/docs에만 Rest docs가 생성되었습니다. 수정된 코드는 JAR 패키지 내부에도 Rest Docs가 생성되도록 수정했습니다. 로컬에서만 보이는 이유가 이거였네요!

아래는 참고 사이트입니다.

[Spring Rest Docs 공식 문서](https://docs.spring.io/spring-restdocs/docs/current/reference/htmlsingle/#getting-started-build-configuration-packaging-the-documentation)

[REST Docs](https://velog.io/@ohzzi/REST-Docs-%EC%96%B4%EB%94%9C-%EB%B3%B4%EC%8B%9C%EB%8A%94-%EA%B1%B0%EC%A3%A0-%EA%B7%B8%EA%B1%B4-%EC%A0%9C-%EC%9E%94%EC%83%81%EC%9E%85%EB%8B%88%EB%8B%A4%EB%A7%8C)

[Doo-re Infra(2) - Gradle과 JAR](https://02ggang9.github.io/infra/DooreInfra3/)

## 💬 리뷰 요구사항(선택)

빌드 테스트를 몇 차례 해봤지만 조금 불안하네요! 혹시 수상한 점 있으시면 리뷰 부탁드리겠습니다~! 이것도 문서화 하겠습니닷

## ⏰ 예상했던 소요시간/실제 소요시간(선택)

2 Hour / 8 Hour