### PR TITLE
Feature/#41-Gradle 캐싱 적용

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -69,7 +69,9 @@ jobs:
         with:
           gradle-version: 8.5
           arguments: build
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'ref/heads/develop' && github.ref != 'refs/heads/Feature/#41-CICD_과정_중_캐싱_적용'}}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'ref/heads/develop' && github.ref != 'refs/heads/Feature/#41-CICD_과정_중_캐싱_적용' }}
+
+      - run: java -Djarmode=layertools -jar build/libs/doore-0.0.1-SNAPSHOT.jar extract
 
       - name: Compress
         run: |

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           gradle-version: 8.5
           arguments: build
-          cache-read-only: ${{ github.ref != 'refs/heads/main && github.ref != 'ref/heads/develop' }}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'ref/heads/develop' }}
 
       - name: Compress
         run: |

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -43,14 +43,12 @@ jobs:
             ~/db-docker-image/doo-re-db.tar \
             $ECR_REGISTRY/doo-re-dev:${{ secrets.DOORE_DB_TAG }}
 
-        # 메인 브랜치 완성 후 수정 예정
       - name: Create Docker Env File
         # working-directory: ./docker 
         run: |
           echo '${{ secrets.DOCKER_ENV }}' >> .env
           echo "ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> .env
 
-        # develop 브랜치에 docker/docker-compose 파일 생성 후 삭제 예정
       - name: Create Docker Compose File
         run: |
           echo '${{ secrets.DOCKER_COMPOSE }}' >> docker-compose.yml
@@ -66,10 +64,12 @@ jobs:
       - name: Start Containers
         run: docker-compose -p doo-re up -d
 
-      - name: Build & Test
-        run: |
-          ./gradlew build --daemon --build-cache && ./gradlew build --daemon --build-cache
-          java -Djarmode=layertools -jar build/libs/doore-0.0.1-SNAPSHOT.jar extract
+      - name: Gradle Build & Test
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 8.5
+          arguments: build
+          cache-read-only: ${{ github.ref != 'refs/heads/main && github.ref != 'ref/heads/develop' }}
 
       - name: Compress
         run: |

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           gradle-version: 8.5
           arguments: build
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'ref/heads/develop' && github.ref != 'refs/heads/Feature/#41-CICD_과정_중_캐싱_적용' }}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'ref/heads/develop' }}
 
       - run: java -Djarmode=layertools -jar build/libs/doore-0.0.1-SNAPSHOT.jar extract
 

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           gradle-version: 8.5
           arguments: build
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'ref/heads/develop' }}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'ref/heads/develop' && github.ref != 'refs/heads/Feature/#41-CICD_과정_중_캐싱_적용'}}
 
       - name: Compress
         run: |


### PR DESCRIPTION
## #️⃣ 연관된 이슈

https://github.com/BDD-CLUB/01-doo-re-back/issues/41

## 📝 작업 내용

Gradle 캐싱하도록 했습니다. 코드 몇 줄만 넣으면 되는데 공식 문서를 보니 어질어질하네요.. 주의점 같은거랑 기타 사항 문서화 잘 하도록 하겠습니다.

develop과 main 브랜치만 캐시 읽기/쓰기가 가능하고 다른 브랜치에서는 캐시 읽기만 가능합니다. Gradle 버전은 doore 프로젝트에 맞게 8.5를 땡겨옵니다.

머지되고 캐싱이 잘 되는지 확인해 보고 싶네요..!

+) 현재 브랜치도 읽기/쓰기 가능하게 하고 테스트 해본 결과 캐싱 잘 되네요! 그런데 Rest Docs는 아직도 해결이...

아래는 정리한 문서입니다.

[Infra - Gradle Cache](https://02ggang9.github.io/infra/GradleCache/)

## ⏰ 예상했던 소요시간/실제 소요시간(선택)

3시간