### PR TITLE
Feature/#14 스터디 crud 기능 구현

### DIFF
--- a/src/docs/asciidoc/study.adoc
+++ b/src/docs/asciidoc/study.adoc
@@ -57,7 +57,7 @@ include::{snippets}/study-update/request-fields.adoc[]
 include::{snippets}/study-update/http-response.adoc[]
 
 
-== `POST`: Study 종료
+== `PATCH`: Study 종료
 
 .HTTP Request
 include::{snippets}/study-terminate/http-request.adoc[]

--- a/src/docs/asciidoc/study.adoc
+++ b/src/docs/asciidoc/study.adoc
@@ -64,3 +64,12 @@ include::{snippets}/study-terminate/http-request.adoc[]
 
 .HTTP Response
 include::{snippets}/study-terminate/http-response.adoc[]
+
+
+== `PATCH`: Study 상태 수정
+
+.HTTP Request
+include::{snippets}/study-change-status/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/study-change-status/http-response.adoc[]

--- a/src/docs/asciidoc/study.adoc
+++ b/src/docs/asciidoc/study.adoc
@@ -1,0 +1,66 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= STUDY API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+== API 목록
+
+link:../doore.html[API 목록으로 돌아가기]
+
+== `POST`: Study 생성
+
+.HTTP Request
+include::{snippets}/study-create/http-request.adoc[]
+
+.Request Fields
+include::{snippets}/study-create/request-fields.adoc[]
+
+.HTTP Response
+include::{snippets}/study-create/http-response.adoc[]
+
+== `GET`: Study 조회
+
+.HTTP Request
+include::{snippets}/study-get/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/study-get/http-response.adoc[]
+
+.Response Body
+include::{snippets}/study-get/response-body.adoc[]
+
+== `DELETE`: Study 삭제
+
+.HTTP Request
+include::{snippets}/study-delete/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/study-delete/http-response.adoc[]
+//todo: 문제 해결
+
+== `PATCH`: Study 수정
+
+.HTTP Request
+include::{snippets}/study-update/http-request.adoc[]
+
+.Request Fields
+include::{snippets}/study-update/request-fields.adoc[]
+
+.HTTP Response
+include::{snippets}/study-update/http-response.adoc[]
+
+
+== `POST`: Study 종료
+
+.HTTP Request
+include::{snippets}/study-terminate/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/study-terminate/http-response.adoc[]

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,8 +42,8 @@ public class StudyController {
         return studyQueryService.findStudyById(studyId);
     }
 
-    @PatchMapping("/studies/{studyId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/studies/{studyId}")
+    @ResponseStatus(HttpStatus.OK)
     public void updateStudy(@Valid @RequestBody StudyUpdateRequest studyUpdateRequest, @PathVariable Long studyId) {
         studyCommandService.updateStudy(studyUpdateRequest, studyId);
     }

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -45,9 +45,9 @@ public class StudyController {
         studyService.updateStudy(studyUpdateRequest, studyId);
     }
 
-    @PostMapping("/studies/{studyId}/termination")
-    @ResponseStatus(HttpStatus.OK)
-    public StudyDetailResponse terminateStudy(@PathVariable Long studyId) {
-        return studyService.terminateStudy(studyId);
+    @PatchMapping("/studies/{studyId}/termination")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void terminateStudy(@PathVariable Long studyId) {
+        studyService.terminateStudy(studyId);
     }
 }

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -51,6 +52,13 @@ public class StudyController {
     public ResponseEntity<Void> updateStudy(@Valid @RequestBody StudyUpdateRequest studyUpdateRequest, @PathVariable Long studyId) {
         studyCommandService.updateStudy(studyUpdateRequest, studyId);
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PatchMapping("/studies/{studyId}/status")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ResponseEntity<Void> changeStudyStatus(@RequestParam String status, @PathVariable Long studyId) {
+        studyCommandService.changeStudyStatus(status, studyId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @PatchMapping("/studies/{studyId}/termination")

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -1,0 +1,53 @@
+package doore.study.api;
+
+import doore.study.application.dto.request.StudyUpdateRequest;
+import doore.study.application.dto.response.StudyDetailResponse;
+import doore.study.application.dto.request.StudyCreateRequest;
+import doore.study.application.StudyService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StudyController {
+    private final StudyService studyService;
+
+    @PostMapping("/teams/{teamId}/studies")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createStudy(@Valid @RequestBody StudyCreateRequest studyRequest, @PathVariable Long teamId) {
+        studyService.createStudy(studyRequest, teamId);
+    }
+
+    @DeleteMapping("/studies/{studyId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteStudy(@PathVariable Long studyId) {
+        studyService.deleteStudy(studyId);
+    }
+
+    @GetMapping("/studies/{studyId}")
+    @ResponseStatus(HttpStatus.OK)
+    public StudyDetailResponse getStudy(@PathVariable Long studyId) {
+        return studyService.findStudyById(studyId);
+    }
+
+    @PatchMapping("/studies/{studyId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateStudy(@Valid @RequestBody StudyUpdateRequest studyUpdateRequest, @PathVariable Long studyId) {
+        studyService.updateStudy(studyUpdateRequest, studyId);
+    }
+
+    @PostMapping("/studies/{studyId}/termination")
+    @ResponseStatus(HttpStatus.OK)
+    public StudyDetailResponse terminateStudy(@PathVariable Long studyId) {
+        return studyService.terminateStudy(studyId);
+    }
+}

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -8,6 +8,7 @@ import doore.study.application.dto.request.StudyCreateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 public class StudyController {

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -1,9 +1,10 @@
 package doore.study.api;
 
+import doore.study.application.StudyCommandService;
+import doore.study.application.StudyQueryService;
 import doore.study.application.dto.request.StudyUpdateRequest;
 import doore.study.application.dto.response.StudyDetailResponse;
 import doore.study.application.dto.request.StudyCreateRequest;
-import doore.study.application.StudyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,35 +20,36 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class StudyController {
-    private final StudyService studyService;
+    private final StudyCommandService studyCommandService;
+    private final StudyQueryService studyQueryService;
 
     @PostMapping("/teams/{teamId}/studies")
     @ResponseStatus(HttpStatus.CREATED)
     public void createStudy(@Valid @RequestBody StudyCreateRequest studyRequest, @PathVariable Long teamId) {
-        studyService.createStudy(studyRequest, teamId);
+        studyCommandService.createStudy(studyRequest, teamId);
     }
 
     @DeleteMapping("/studies/{studyId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteStudy(@PathVariable Long studyId) {
-        studyService.deleteStudy(studyId);
+        studyCommandService.deleteStudy(studyId);
     }
 
     @GetMapping("/studies/{studyId}")
     @ResponseStatus(HttpStatus.OK)
     public StudyDetailResponse getStudy(@PathVariable Long studyId) {
-        return studyService.findStudyById(studyId);
+        return studyQueryService.findStudyById(studyId);
     }
 
     @PatchMapping("/studies/{studyId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateStudy(@Valid @RequestBody StudyUpdateRequest studyUpdateRequest, @PathVariable Long studyId) {
-        studyService.updateStudy(studyUpdateRequest, studyId);
+        studyCommandService.updateStudy(studyUpdateRequest, studyId);
     }
 
     @PatchMapping("/studies/{studyId}/termination")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void terminateStudy(@PathVariable Long studyId) {
-        studyService.terminateStudy(studyId);
+        studyCommandService.terminateStudy(studyId);
     }
 }

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -8,6 +8,7 @@ import doore.study.application.dto.request.StudyCreateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,32 +28,35 @@ public class StudyController {
     private final StudyQueryService studyQueryService;
 
     @PostMapping("/teams/{teamId}/studies")
-    @ResponseStatus(HttpStatus.CREATED)
-    public void createStudy(@Valid @RequestBody StudyCreateRequest studyRequest, @PathVariable Long teamId) {
+    public ResponseEntity<Void> createStudy(@Valid @RequestBody StudyCreateRequest studyRequest, @PathVariable Long teamId) {
         studyCommandService.createStudy(studyRequest, teamId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @DeleteMapping("/studies/{studyId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteStudy(@PathVariable Long studyId) {
+    public ResponseEntity<Void> deleteStudy(@PathVariable Long studyId) {
         studyCommandService.deleteStudy(studyId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @GetMapping("/studies/{studyId}")
     @ResponseStatus(HttpStatus.OK)
-    public StudyDetailResponse getStudy(@PathVariable Long studyId) {
-        return studyQueryService.findStudyById(studyId);
+    public ResponseEntity<StudyDetailResponse> getStudy(@PathVariable Long studyId) {
+        StudyDetailResponse studyDetailResponse = studyQueryService.findStudyById(studyId);
+        return ResponseEntity.ok(studyDetailResponse);
     }
 
     @PutMapping("/studies/{studyId}")
     @ResponseStatus(HttpStatus.OK)
-    public void updateStudy(@Valid @RequestBody StudyUpdateRequest studyUpdateRequest, @PathVariable Long studyId) {
+    public ResponseEntity<Void> updateStudy(@Valid @RequestBody StudyUpdateRequest studyUpdateRequest, @PathVariable Long studyId) {
         studyCommandService.updateStudy(studyUpdateRequest, studyId);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PatchMapping("/studies/{studyId}/termination")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void terminateStudy(@PathVariable Long studyId) {
+    public ResponseEntity<Void> terminateStudy(@PathVariable Long studyId) {
         studyCommandService.terminateStudy(studyId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -41,28 +41,24 @@ public class StudyController {
     }
 
     @GetMapping("/studies/{studyId}")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<StudyDetailResponse> getStudy(@PathVariable Long studyId) {
         StudyDetailResponse studyDetailResponse = studyQueryService.findStudyById(studyId);
         return ResponseEntity.ok(studyDetailResponse);
     }
 
     @PutMapping("/studies/{studyId}")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<Void> updateStudy(@Valid @RequestBody StudyUpdateRequest studyUpdateRequest, @PathVariable Long studyId) {
         studyCommandService.updateStudy(studyUpdateRequest, studyId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PatchMapping("/studies/{studyId}/status")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> changeStudyStatus(@RequestParam String status, @PathVariable Long studyId) {
         studyCommandService.changeStudyStatus(status, studyId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @PatchMapping("/studies/{studyId}/termination")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> terminateStudy(@PathVariable Long studyId) {
         studyCommandService.terminateStudy(studyId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -1,7 +1,7 @@
 package doore.study.application;
 
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
-import static doore.study.exception.StudyExceptionType.TERMINATED_STUDY;
+import static doore.study.exception.StudyExceptionType.ALREADY_TERMINATED_STUDY;
 
 import doore.study.application.dto.request.StudyCreateRequest;
 import doore.study.application.dto.request.StudyUpdateRequest;
@@ -46,7 +46,7 @@ public class StudyCommandService {
     public void terminateStudy(Long studyId) {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
         if (study.isEnded()) {
-            throw new StudyException(TERMINATED_STUDY);
+            throw new StudyException(ALREADY_TERMINATED_STUDY);
         }
         study.terminate();
     }

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -45,21 +45,22 @@ public class StudyCommandService {
     }
 
     public void deleteStudy(Long studyId) {
+        checkExistStudy(studyId);
         studyRepository.deleteById(studyId);
     }
 
     public void updateStudy(StudyUpdateRequest request, Long studyId) {
-        Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+        Study study = checkExistStudy(studyId);
         study.update(request.name(), request.description(), request.startDate(), request.endDate(), request.status());
     }
 
     public void terminateStudy(Long studyId) {
-        Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+        Study study = checkExistStudy(studyId);
         study.terminate();
     }
 
     public void changeStudyStatus(String status, Long studyId) {
-        Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+        Study study = checkExistStudy(studyId);
         try {
             StudyStatus changedStatus = StudyStatus.valueOf(status);
             study.changeStatus(changedStatus);
@@ -70,6 +71,10 @@ public class StudyCommandService {
 
     private void checkExistTeam(Long teamId) {
         teamRepository.findById(teamId).orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM));
+    }
+
+    public Study checkExistStudy(Long studyId) {
+        return studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
     }
 
     public Study toStudyWithoutCurriculum(StudyCreateRequest request, Long teamId) {

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -30,7 +30,7 @@ public class StudyCommandService {
     private final CurriculumItemRepository curriculumItemRepository;
 
     public void createStudy(final StudyCreateRequest request, final Long teamId) {
-        teamRepository.findById(teamId).orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM));
+        checkExistTeam(teamId);
         Study study = studyRepository.save(request.toEntityWithoutCurriculum(teamId));
         List<CurriculumItem> curriculumItems = request.toCurriculumListEntity(study);
         curriculumItemRepository.saveAll(curriculumItems);
@@ -61,5 +61,9 @@ public class StudyCommandService {
         } catch (IllegalArgumentException e) {
             throw new StudyException(NOT_FOUND_STATUS);
         }
+    }
+
+    private void checkExistTeam(Long teamId) {
+        teamRepository.findById(teamId).orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM));
     }
 }

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -55,9 +55,6 @@ public class StudyCommandService {
 
     public void terminateStudy(Long studyId) {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
-        if (study.isEnded()) {
-            throw new StudyException(ALREADY_TERMINATED_STUDY);
-        }
         study.terminate();
     }
 

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -1,21 +1,20 @@
 package doore.study.application;
 
-import static doore.study.domain.StudyStatus.ENDED;
-import static doore.study.exception.StudyExceptionType.*;
+import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
+import static doore.study.exception.StudyExceptionType.TERMINATED_STUDY;
 
-import doore.study.application.dto.request.StudyUpdateRequest;
-import doore.study.application.dto.response.StudyDetailResponse;
 import doore.study.application.dto.request.StudyCreateRequest;
+import doore.study.application.dto.request.StudyUpdateRequest;
 import doore.study.domain.CurriculumItem;
 import doore.study.domain.Study;
 import doore.study.domain.repository.CurriculumItemRepository;
 import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
-import doore.team.application.TeamCommandService;
 import doore.team.domain.TeamRepository;
 import doore.team.exception.TeamException;
 import doore.team.exception.TeamExceptionType;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class StudyService {
+public class StudyCommandService {
     private final StudyRepository studyRepository;
     private final TeamRepository teamRepository;
     private final CurriculumItemRepository curriculumItemRepository;
@@ -37,12 +36,6 @@ public class StudyService {
 
     public void deleteStudy(Long studyId) {
         studyRepository.deleteById(studyId);
-    }
-
-    @Transactional(readOnly = true)
-    public StudyDetailResponse findStudyById(Long studyId) {
-        Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
-        return StudyDetailResponse.from(study);
     }
 
     public void updateStudy(StudyUpdateRequest request, Long studyId) {

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -44,6 +44,32 @@ public class StudyCommandService {
         }
     }
 
+    public Study toStudyWithoutCurriculum(StudyCreateRequest request, Long teamId) {
+        return Study.builder()
+                .name(request.name())
+                .description(request.description())
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .status(UPCOMING)
+                .isDeleted(false)
+                .teamId(teamId)
+                .cropId(request.cropId())
+                .build();
+    }
+
+    public List<CurriculumItem> toCurriculumList(StudyCreateRequest request, Study study) {
+        return request.curriculumItems().stream()
+                .map(curriculumItemsRequest -> extractCurriculumItemFromStudy(curriculumItemsRequest, study))
+                .toList();
+    }
+
+    public CurriculumItem extractCurriculumItemFromStudy(CurriculumItemsRequest request, Study study) {
+        return CurriculumItem.builder()
+                .name(request.name())
+                .study(study)
+                .build();
+    }
+
     public void deleteStudy(Long studyId) {
         checkExistStudy(studyId);
         studyRepository.deleteById(studyId);
@@ -75,31 +101,5 @@ public class StudyCommandService {
 
     public Study checkExistStudy(Long studyId) {
         return studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
-    }
-
-    public Study toStudyWithoutCurriculum(StudyCreateRequest request, Long teamId) {
-        return Study.builder()
-                .name(request.name())
-                .description(request.description())
-                .startDate(request.startDate())
-                .endDate(request.endDate())
-                .status(UPCOMING)
-                .isDeleted(false)
-                .teamId(teamId)
-                .cropId(request.cropId())
-                .build();
-    }
-
-    public List<CurriculumItem> toCurriculumList(StudyCreateRequest request, Study study) {
-        return request.curriculumItems().stream()
-                .map(curriculumItemsRequest -> extractCurriculumItemFromStudy(curriculumItemsRequest, study))
-                .toList();
-    }
-
-    public CurriculumItem extractCurriculumItemFromStudy(CurriculumItemsRequest request, Study study) {
-        return CurriculumItem.builder()
-                .name(request.name())
-                .study(study)
-                .build();
     }
 }

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -1,5 +1,6 @@
 package doore.study.application;
 
+import static doore.study.exception.StudyExceptionType.NOT_FOUND_STATUS;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 import static doore.study.exception.StudyExceptionType.ALREADY_TERMINATED_STUDY;
 
@@ -7,6 +8,7 @@ import doore.study.application.dto.request.StudyCreateRequest;
 import doore.study.application.dto.request.StudyUpdateRequest;
 import doore.study.domain.CurriculumItem;
 import doore.study.domain.Study;
+import doore.study.domain.StudyStatus;
 import doore.study.domain.repository.CurriculumItemRepository;
 import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
@@ -49,5 +51,15 @@ public class StudyCommandService {
             throw new StudyException(ALREADY_TERMINATED_STUDY);
         }
         study.terminate();
+    }
+
+    public void changeStudyStatus(String status, Long studyId) {
+        Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+        try {
+            StudyStatus changedStatus = StudyStatus.valueOf(status);
+            study.changeStatus(changedStatus);
+        } catch (IllegalArgumentException e) {
+            throw new StudyException(NOT_FOUND_STATUS);
+        }
     }
 }

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -94,8 +94,6 @@ public class StudyCommandService {
     public CurriculumItem extractCurriculumItemFromStudy(CurriculumItemsRequest request, Study study) {
         return CurriculumItem.builder()
                 .name(request.name())
-                .itemOrder(request.itemOrder())
-                .isDeleted(request.isDeleted())
                 .study(study)
                 .build();
     }

--- a/src/main/java/doore/study/application/StudyQueryService.java
+++ b/src/main/java/doore/study/application/StudyQueryService.java
@@ -1,0 +1,25 @@
+package doore.study.application;
+
+import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
+
+import doore.study.application.dto.response.StudyDetailResponse;
+import doore.study.domain.Study;
+import doore.study.domain.repository.CurriculumItemRepository;
+import doore.study.domain.repository.StudyRepository;
+import doore.study.exception.StudyException;
+import doore.team.domain.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StudyQueryService {
+    private final StudyRepository studyRepository;
+
+    public StudyDetailResponse findStudyById(Long studyId) {
+        Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+        return StudyDetailResponse.from(study);
+    }
+}

--- a/src/main/java/doore/study/application/StudyService.java
+++ b/src/main/java/doore/study/application/StudyService.java
@@ -55,6 +55,6 @@ public class StudyService {
         if (study.isEnded()) {
             throw new StudyException(TERMINATED_STUDY);
         }
-        study.setStatus(ENDED);
+        study.terminate();
     }
 }

--- a/src/main/java/doore/study/application/StudyService.java
+++ b/src/main/java/doore/study/application/StudyService.java
@@ -45,12 +45,11 @@ public class StudyService {
         study.update(request);
     }
 
-    public StudyDetailResponse terminateStudy(Long studyId) {
+    public void terminateStudy(Long studyId) {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
         if (study.getStatus() == ENDED) {
             throw new StudyException(TERMINATED_STUDY);
         }
         study.setStatus(ENDED);
-        return StudyDetailResponse.from(study);
     }
 }

--- a/src/main/java/doore/study/application/StudyService.java
+++ b/src/main/java/doore/study/application/StudyService.java
@@ -28,7 +28,6 @@ public class StudyService {
         Study study = studyRepository.save(request.toEntityWithoutCurriculum(teamId));
         List<CurriculumItem> curriculumItems = request.toCurriculumListEntity(study);
         curriculumItemRepository.saveAll(curriculumItems);
-        study.createCurriculumItems(curriculumItems);
     }
 
     public void deleteStudy(Long studyId) {

--- a/src/main/java/doore/study/application/StudyService.java
+++ b/src/main/java/doore/study/application/StudyService.java
@@ -47,7 +47,7 @@ public class StudyService {
 
     public void updateStudy(StudyUpdateRequest request, Long studyId) {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
-        study.update(request);
+        study.update(request.name(), request.description(), request.startDate(), request.endDate(), request.status());
     }
 
     public void terminateStudy(Long studyId) {

--- a/src/main/java/doore/study/application/StudyService.java
+++ b/src/main/java/doore/study/application/StudyService.java
@@ -1,0 +1,58 @@
+package doore.study.application;
+
+import static doore.study.domain.StudyStatus.ENDED;
+import static doore.study.exception.StudyExceptionType.*;
+
+import doore.study.application.dto.request.StudyUpdateRequest;
+import doore.study.application.dto.response.StudyDetailResponse;
+import doore.study.application.dto.request.StudyCreateRequest;
+import doore.study.domain.CurriculumItem;
+import doore.study.domain.Study;
+import doore.study.domain.repository.CurriculumItemRepository;
+import doore.study.domain.repository.StudyRepository;
+import doore.study.exception.StudyException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StudyService {
+    private final StudyRepository studyRepository;
+    private final CurriculumItemRepository curriculumItemRepository;
+
+    public void createStudy(final StudyCreateRequest request, final Long teamId) {
+        //todo: 존재하는 팀인지 유효성 검사
+        Study study = studyRepository.save(request.toEntityWithoutCurriculum(teamId));
+        List<CurriculumItem> curriculumItems = request.toCurriculumListEntity(study);
+        curriculumItemRepository.saveAll(curriculumItems);
+        study.createCurriculumItems(curriculumItems);
+    }
+
+    public void deleteStudy(Long studyId) {
+        studyRepository.deleteById(studyId);
+    }
+
+    @Transactional(readOnly = true)
+    public StudyDetailResponse findStudyById(Long studyId) {
+        Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+        return StudyDetailResponse.from(study);
+    }
+
+    public void updateStudy(StudyUpdateRequest request, Long studyId) {
+        Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+        study.update(request);
+        studyRepository.save(study);
+    }
+
+    public StudyDetailResponse terminateStudy(Long studyId) {
+        Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+        if (study.getStatus() == ENDED) {
+            throw new StudyException(TERMINATED_STUDY);
+        }
+        study.setStatus(ENDED);
+        return StudyDetailResponse.from(study);
+    }
+}

--- a/src/main/java/doore/study/application/StudyService.java
+++ b/src/main/java/doore/study/application/StudyService.java
@@ -44,7 +44,6 @@ public class StudyService {
     public void updateStudy(StudyUpdateRequest request, Long studyId) {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
         study.update(request);
-        studyRepository.save(study);
     }
 
     public StudyDetailResponse terminateStudy(Long studyId) {

--- a/src/main/java/doore/study/application/StudyService.java
+++ b/src/main/java/doore/study/application/StudyService.java
@@ -52,7 +52,7 @@ public class StudyService {
 
     public void terminateStudy(Long studyId) {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
-        if (study.getStatus() == ENDED) {
+        if (study.isEnded()) {
             throw new StudyException(TERMINATED_STUDY);
         }
         study.setStatus(ENDED);

--- a/src/main/java/doore/study/application/StudyService.java
+++ b/src/main/java/doore/study/application/StudyService.java
@@ -11,6 +11,10 @@ import doore.study.domain.Study;
 import doore.study.domain.repository.CurriculumItemRepository;
 import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
+import doore.team.application.TeamCommandService;
+import doore.team.domain.TeamRepository;
+import doore.team.exception.TeamException;
+import doore.team.exception.TeamExceptionType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,10 +25,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StudyService {
     private final StudyRepository studyRepository;
+    private final TeamRepository teamRepository;
     private final CurriculumItemRepository curriculumItemRepository;
 
     public void createStudy(final StudyCreateRequest request, final Long teamId) {
-        //todo: 존재하는 팀인지 유효성 검사
+        teamRepository.findById(teamId).orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM));
         Study study = studyRepository.save(request.toEntityWithoutCurriculum(teamId));
         List<CurriculumItem> curriculumItems = request.toCurriculumListEntity(study);
         curriculumItemRepository.saveAll(curriculumItems);

--- a/src/main/java/doore/study/application/dto/request/CurriculumItemsRequest.java
+++ b/src/main/java/doore/study/application/dto/request/CurriculumItemsRequest.java
@@ -12,12 +12,4 @@ public record CurriculumItemsRequest(
         @NotNull
         Boolean isDeleted
 ) {
-    public CurriculumItem toEntity(Study study) {
-        return CurriculumItem.builder()
-                .name(this.name())
-                .itemOrder(this.itemOrder())
-                .isDeleted(this.isDeleted())
-                .study(study)
-                .build();
-    }
 }

--- a/src/main/java/doore/study/application/dto/request/CurriculumItemsRequest.java
+++ b/src/main/java/doore/study/application/dto/request/CurriculumItemsRequest.java
@@ -6,12 +6,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record CurriculumItemsRequest(
         @NotNull(message = "이름을 입력해주세요.")
-        String name,
-
-        @NotNull(message = "커리큘럼 순서를 입력해주세요.")
-        Integer itemOrder,
-
-        @NotNull(message = "커리큘럼 삭제여부를 입력해주세요.")
-        Boolean isDeleted
+        String name
 ) {
 }

--- a/src/main/java/doore/study/application/dto/request/CurriculumItemsRequest.java
+++ b/src/main/java/doore/study/application/dto/request/CurriculumItemsRequest.java
@@ -1,0 +1,23 @@
+package doore.study.application.dto.request;
+
+import doore.study.domain.CurriculumItem;
+import doore.study.domain.Study;
+import jakarta.validation.constraints.NotNull;
+
+public record CurriculumItemsRequest(
+        @NotNull(message = "이름을 입력해주세요.")
+        String name,
+        @NotNull
+        Integer itemOrder,
+        @NotNull
+        Boolean isDeleted
+) {
+    public CurriculumItem toEntity(Study study) {
+        return CurriculumItem.builder()
+                .name(this.name())
+                .itemOrder(this.itemOrder())
+                .isDeleted(this.isDeleted())
+                .study(study)
+                .build();
+    }
+}

--- a/src/main/java/doore/study/application/dto/request/CurriculumItemsRequest.java
+++ b/src/main/java/doore/study/application/dto/request/CurriculumItemsRequest.java
@@ -7,9 +7,11 @@ import jakarta.validation.constraints.NotNull;
 public record CurriculumItemsRequest(
         @NotNull(message = "이름을 입력해주세요.")
         String name,
-        @NotNull
+
+        @NotNull(message = "커리큘럼 순서를 입력해주세요.")
         Integer itemOrder,
-        @NotNull
+
+        @NotNull(message = "커리큘럼 삭제여부를 입력해주세요.")
         Boolean isDeleted
 ) {
 }

--- a/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
@@ -30,18 +30,18 @@ public record StudyCreateRequest(
         @NotNull(message = "작물을 골라주세요.")
         Long cropId,
 
-        @Nullable
+        @NotNull
         List<CurriculumItemsRequest> curriculumItems
 ) {
     @Builder
-    public StudyCreateRequest(String name, String description, LocalDate startDate, @Nullable LocalDate endDate,
+    public StudyCreateRequest(String name, String description, LocalDate startDate, LocalDate endDate,
                               Long cropId, List<CurriculumItemsRequest> curriculumItems) {
         this.name = name;
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
         this.cropId = cropId;
-        this.curriculumItems = curriculumItems;
+        this.curriculumItems = curriculumItems == null ? Collections.emptyList(): curriculumItems;
     }
 
     public Study toEntityWithoutCurriculum(Long teamId) {
@@ -58,9 +58,6 @@ public record StudyCreateRequest(
     }
 
     public List<CurriculumItem> toCurriculumListEntity(Study study) {
-        if (this.curriculumItems == null) {
-            return Collections.emptyList();
-        }
         return curriculumItems.stream()
                 .map(curriculumItemsRequest -> curriculumItemsRequest.toEntity(study))
                 .toList();

--- a/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
@@ -43,23 +43,4 @@ public record StudyCreateRequest(
         this.cropId = cropId;
         this.curriculumItems =  Collections.emptyList();
     }
-
-    public Study toEntityWithoutCurriculum(Long teamId) {
-        return Study.builder()
-                .name(this.name())
-                .description(this.description())
-                .startDate(this.startDate())
-                .endDate(this.endDate())
-                .status(UPCOMING)
-                .isDeleted(false)
-                .teamId(teamId)
-                .cropId(this.cropId())
-                .build();
-    }
-
-    public List<CurriculumItem> toCurriculumListEntity(Study study) {
-        return curriculumItems.stream()
-                .map(curriculumItemsRequest -> curriculumItemsRequest.toEntity(study))
-                .toList();
-    }
 }

--- a/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
@@ -1,0 +1,76 @@
+package doore.study.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import doore.study.domain.CurriculumItem;
+import doore.study.domain.Study;
+import doore.study.domain.StudyStatus;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import lombok.Builder;
+
+public record StudyCreateRequest(
+        @NotNull(message = "이름을 입력해주세요.")
+        String name,
+
+        @NotNull(message = "설명을 입력해주세요.")
+        String description,
+
+        @NotNull(message = "시작 날짜를 입력해주세요.")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @Nullable
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        @NotNull(message = "현재 상태를 입력해주세요.")
+        StudyStatus status,
+
+        @NotNull
+        Boolean isDeleted,
+
+        @NotNull(message = "작물을 골라주세요.")
+        Long cropId,
+
+        @Nullable
+        List<CurriculumItemsRequest> curriculumItems
+) {
+    @Builder
+    public StudyCreateRequest(String name, String description, LocalDate startDate, LocalDate endDate,
+                              StudyStatus status,
+                              Boolean isDeleted, Long cropId, List<CurriculumItemsRequest> curriculumItems) {
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+        this.isDeleted = isDeleted;
+        this.cropId = cropId;
+        this.curriculumItems = curriculumItems;
+    }
+
+    public Study toEntityWithoutCurriculum(Long teamId) {
+        return Study.builder()
+                .name(this.name())
+                .description(this.description())
+                .startDate(this.startDate())
+                .endDate(this.endDate())
+                .status(this.status())
+                .isDeleted(this.isDeleted())
+                .teamId(teamId)
+                .cropId(this.cropId())
+                .build();
+    }
+
+    public List<CurriculumItem> toCurriculumListEntity(Study study) {
+        if (this.curriculumItems == null) {
+            return Collections.emptyList();
+        }
+        return curriculumItems.stream()
+                .map(curriculumItemsRequest -> curriculumItemsRequest.toEntity(study))
+                .toList();
+    }
+}

--- a/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
@@ -1,9 +1,10 @@
 package doore.study.application.dto.request;
 
+import static doore.study.domain.StudyStatus.UPCOMING;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import doore.study.domain.CurriculumItem;
 import doore.study.domain.Study;
-import doore.study.domain.StudyStatus;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -26,12 +27,6 @@ public record StudyCreateRequest(
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate endDate,
 
-        @NotNull(message = "현재 상태를 입력해주세요.")
-        StudyStatus status,
-
-        @NotNull
-        Boolean isDeleted,
-
         @NotNull(message = "작물을 골라주세요.")
         Long cropId,
 
@@ -39,15 +34,12 @@ public record StudyCreateRequest(
         List<CurriculumItemsRequest> curriculumItems
 ) {
     @Builder
-    public StudyCreateRequest(String name, String description, LocalDate startDate, LocalDate endDate,
-                              StudyStatus status, Boolean isDeleted, Long cropId,
-                              List<CurriculumItemsRequest> curriculumItems) {
+    public StudyCreateRequest(String name, String description, LocalDate startDate, @Nullable LocalDate endDate,
+                              Long cropId, List<CurriculumItemsRequest> curriculumItems) {
         this.name = name;
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.status = status;
-        this.isDeleted = isDeleted;
         this.cropId = cropId;
         this.curriculumItems = curriculumItems;
     }
@@ -58,8 +50,8 @@ public record StudyCreateRequest(
                 .description(this.description())
                 .startDate(this.startDate())
                 .endDate(this.endDate())
-                .status(this.status())
-                .isDeleted(this.isDeleted())
+                .status(UPCOMING)
+                .isDeleted(false)
                 .teamId(teamId)
                 .cropId(this.cropId())
                 .build();

--- a/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import lombok.Builder;
 
+@Builder
 public record StudyCreateRequest(
         @NotNull(message = "이름을 입력해주세요.")
         String name,
@@ -33,7 +34,6 @@ public record StudyCreateRequest(
         @NotNull(message = "커리큘럼을 입력해주세요.")
         List<CurriculumItemsRequest> curriculumItems
 ) {
-    @Builder
     public StudyCreateRequest(String name, String description, LocalDate startDate, LocalDate endDate,
                               Long cropId, List<CurriculumItemsRequest> curriculumItems) {
         this.name = name;

--- a/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
@@ -41,7 +41,7 @@ public record StudyCreateRequest(
         this.startDate = startDate;
         this.endDate = endDate;
         this.cropId = cropId;
-        this.curriculumItems = curriculumItems == null ? Collections.emptyList(): curriculumItems;
+        this.curriculumItems =  Collections.emptyList();
     }
 
     public Study toEntityWithoutCurriculum(Long teamId) {

--- a/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
@@ -40,8 +40,8 @@ public record StudyCreateRequest(
 ) {
     @Builder
     public StudyCreateRequest(String name, String description, LocalDate startDate, LocalDate endDate,
-                              StudyStatus status,
-                              Boolean isDeleted, Long cropId, List<CurriculumItemsRequest> curriculumItems) {
+                              StudyStatus status, Boolean isDeleted, Long cropId,
+                              List<CurriculumItemsRequest> curriculumItems) {
         this.name = name;
         this.description = description;
         this.startDate = startDate;

--- a/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
@@ -30,7 +30,7 @@ public record StudyCreateRequest(
         @NotNull(message = "작물을 골라주세요.")
         Long cropId,
 
-        @NotNull
+        @NotNull(message = "커리큘럼을 입력해주세요.")
         List<CurriculumItemsRequest> curriculumItems
 ) {
     @Builder

--- a/src/main/java/doore/study/application/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyUpdateRequest.java
@@ -1,0 +1,37 @@
+package doore.study.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import doore.study.domain.StudyStatus;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Builder;
+
+public record StudyUpdateRequest(
+        @NotNull(message = "이름을 입력해주세요.")
+        String name,
+
+        @NotNull(message = "설명을 입력해주세요.")
+        String description,
+
+        @NotNull(message = "시작 날짜를 입력해주세요.")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @Nullable
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        @NotNull(message = "현재 상태를 입력해주세요.")
+        StudyStatus status
+) {
+    @Builder
+    public StudyUpdateRequest(String name, String description, LocalDate startDate, LocalDate endDate,
+                              StudyStatus status) {
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+    }
+}

--- a/src/main/java/doore/study/application/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyUpdateRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.Builder;
 
+@Builder
 public record StudyUpdateRequest(
         @NotNull(message = "이름을 입력해주세요.")
         String name,
@@ -25,7 +26,6 @@ public record StudyUpdateRequest(
         @NotNull(message = "현재 상태를 입력해주세요.")
         StudyStatus status
 ) {
-    @Builder
     public StudyUpdateRequest(String name, String description, LocalDate startDate, LocalDate endDate,
                               StudyStatus status) {
         this.name = name;

--- a/src/main/java/doore/study/application/dto/response/CurriculumItemResponse.java
+++ b/src/main/java/doore/study/application/dto/response/CurriculumItemResponse.java
@@ -1,24 +1,16 @@
 package doore.study.application.dto.response;
 
 import doore.study.domain.CurriculumItem;
-import lombok.Getter;
 
-@Getter
-public class CurriculumItemResponse {
-    Long id;
-    String name;
-    Integer itemOrder;
-    Boolean isDeleted;
-
-    public CurriculumItemResponse(Long id, String name, Integer itemOrder, Boolean isDeleted) {
-        this.id = id;
-        this.name = name;
-        this.itemOrder = itemOrder;
-        this.isDeleted = isDeleted;
-    }
+public record CurriculumItemResponse(
+        Long id,
+        String name,
+        Integer itemOrder,
+        Boolean isDeleted
+) {
 
     public static CurriculumItemResponse from(CurriculumItem curriculumItem) {
-        return new CurriculumItemResponse(curriculumItem.getId(), curriculumItem.getName(),
+       return new CurriculumItemResponse(curriculumItem.getId(), curriculumItem.getName(),
                 curriculumItem.getItemOrder(), curriculumItem.getIsDeleted());
     }
 }

--- a/src/main/java/doore/study/application/dto/response/CurriculumItemResponse.java
+++ b/src/main/java/doore/study/application/dto/response/CurriculumItemResponse.java
@@ -1,0 +1,24 @@
+package doore.study.application.dto.response;
+
+import doore.study.domain.CurriculumItem;
+import lombok.Getter;
+
+@Getter
+public class CurriculumItemResponse {
+    Long id;
+    String name;
+    Integer itemOrder;
+    Boolean isDeleted;
+
+    public CurriculumItemResponse(Long id, String name, Integer itemOrder, Boolean isDeleted) {
+        this.id = id;
+        this.name = name;
+        this.itemOrder = itemOrder;
+        this.isDeleted = isDeleted;
+    }
+
+    public static CurriculumItemResponse from(CurriculumItem curriculumItem) {
+        return new CurriculumItemResponse(curriculumItem.getId(), curriculumItem.getName(),
+                curriculumItem.getItemOrder(), curriculumItem.getIsDeleted());
+    }
+}

--- a/src/main/java/doore/study/application/dto/response/StudyDetailResponse.java
+++ b/src/main/java/doore/study/application/dto/response/StudyDetailResponse.java
@@ -7,47 +7,31 @@ import doore.study.domain.StudyStatus;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
-import lombok.Getter;
 
-@Getter
-public class StudyDetailResponse {
+public record StudyDetailResponse(
 
-    Long id;
+        Long id,
 
-    String name;
+        String name,
 
-    String description;
+        String description,
 
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    LocalDate startDate;
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
 
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    LocalDate endTime;
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endTime,
 
-    StudyStatus status;
+        StudyStatus status,
 
-    Boolean isDeleted;
+        Boolean isDeleted,
 
-    Long teamId;
+        Long teamId,
 
-    Long cropId;
+        Long cropId,
 
-    List<CurriculumItemResponse> curriculumItems;
-
-    public StudyDetailResponse(Long id, String name, String description, LocalDate startDate, LocalDate endDate,
-                               StudyStatus status, Boolean isDeleted, Long teamId, Long cropId,
-                               List<CurriculumItemResponse> curriculumItemResponses) {
-        this.id = id;
-        this.name = name;
-        this.description = description;
-        this.startDate = startDate;
-        this.endTime = endDate;
-        this.status =  status;
-        this.isDeleted = isDeleted;
-        this.teamId = teamId;
-        this.cropId = cropId;
-        this.curriculumItems = curriculumItemResponses;
-    }
+        List<CurriculumItemResponse> curriculumItems
+) {
 
     public static StudyDetailResponse from(Study study) {
         List<CurriculumItem> curriculumItems = study.getCurriculumItems();

--- a/src/main/java/doore/study/application/dto/response/StudyDetailResponse.java
+++ b/src/main/java/doore/study/application/dto/response/StudyDetailResponse.java
@@ -1,0 +1,61 @@
+package doore.study.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import doore.study.domain.CurriculumItem;
+import doore.study.domain.Study;
+import doore.study.domain.StudyStatus;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class StudyDetailResponse {
+
+    Long id;
+
+    String name;
+
+    String description;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate startDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate endTime;
+
+    StudyStatus status;
+
+    Boolean isDeleted;
+
+    Long teamId;
+
+    Long cropId;
+
+    List<CurriculumItemResponse> curriculumItems;
+
+    public StudyDetailResponse(Long id, String name, String description, LocalDate startDate, LocalDate endDate,
+                               StudyStatus status, Boolean isDeleted, Long teamId, Long cropId,
+                               List<CurriculumItemResponse> curriculumItemResponses) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endTime = endDate;
+        this.status =  status;
+        this.isDeleted = isDeleted;
+        this.teamId = teamId;
+        this.cropId = cropId;
+        this.curriculumItems = curriculumItemResponses;
+    }
+
+    public static StudyDetailResponse from(Study study) {
+        List<CurriculumItem> curriculumItems = study.getCurriculumItems();
+        List<CurriculumItemResponse> curriculumItemResponses = curriculumItems == null ? Collections.emptyList()
+                : curriculumItems.stream().map(CurriculumItemResponse::from)
+                        .toList();
+        return new StudyDetailResponse(study.getId(), study.getName(), study.getDescription(), study.getStartDate(),
+                study.getEndDate(), study.getStatus(), study.getIsDeleted(), study.getTeamId(),
+                study.getCropId(), curriculumItemResponses);
+    }
+}

--- a/src/main/java/doore/study/application/dto/response/StudyDetailResponse.java
+++ b/src/main/java/doore/study/application/dto/response/StudyDetailResponse.java
@@ -11,9 +11,7 @@ import java.util.List;
 public record StudyDetailResponse(
 
         Long id,
-
         String name,
-
         String description,
 
         @JsonFormat(pattern = "yyyy-MM-dd")
@@ -21,22 +19,18 @@ public record StudyDetailResponse(
 
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate endTime,
-
         StudyStatus status,
-
         Boolean isDeleted,
-
         Long teamId,
-
         Long cropId,
-
         List<CurriculumItemResponse> curriculumItems
 ) {
 
     public static StudyDetailResponse from(Study study) {
         List<CurriculumItem> curriculumItems = study.getCurriculumItems();
-        List<CurriculumItemResponse> curriculumItemResponses = curriculumItems == null ? Collections.emptyList()
-                : curriculumItems.stream().map(CurriculumItemResponse::from)
+        List<CurriculumItemResponse> curriculumItemResponses =
+                curriculumItems == null ? Collections.emptyList() : curriculumItems.stream()
+                        .map(CurriculumItemResponse::from)
                         .toList();
         return new StudyDetailResponse(study.getId(), study.getName(), study.getDescription(), study.getStartDate(),
                 study.getEndDate(), study.getStatus(), study.getIsDeleted(), study.getTeamId(),

--- a/src/main/java/doore/study/domain/CurriculumItem.java
+++ b/src/main/java/doore/study/domain/CurriculumItem.java
@@ -13,11 +13,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CurriculumItem extends BaseEntity {
 
@@ -43,6 +41,10 @@ public class CurriculumItem extends BaseEntity {
         this.name = name;
         this.itemOrder = itemOrder;
         this.isDeleted = isDeleted;
+        this.study = study;
+    }
+
+    public void saveStudyToCurriculum(Study study) {
         this.study = study;
     }
 }

--- a/src/main/java/doore/study/domain/CurriculumItem.java
+++ b/src/main/java/doore/study/domain/CurriculumItem.java
@@ -10,13 +10,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CurriculumItem extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -34,4 +38,11 @@ public class CurriculumItem extends BaseEntity {
     @JoinColumn(name = "study_id", nullable = false)
     private Study study;
 
+    @Builder
+    public CurriculumItem(String name, Integer itemOrder, Boolean isDeleted, Study study) {
+        this.name = name;
+        this.itemOrder = itemOrder;
+        this.isDeleted = isDeleted;
+        this.study = study;
+    }
 }

--- a/src/main/java/doore/study/domain/CurriculumItem.java
+++ b/src/main/java/doore/study/domain/CurriculumItem.java
@@ -37,14 +37,14 @@ public class CurriculumItem extends BaseEntity {
     private Study study;
 
     @Builder
-    public CurriculumItem(String name, Integer itemOrder, Boolean isDeleted, Study study) {
+    private CurriculumItem(String name, Integer itemOrder, Boolean isDeleted, Study study) {
         this.name = name;
         this.itemOrder = itemOrder;
         this.isDeleted = isDeleted;
         this.study = study;
     }
 
-    public void saveStudyToCurriculum(Study study) {
+    public void saveStudy(Study study) {
         this.study = study;
     }
 }

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -75,6 +75,10 @@ public class Study extends BaseEntity {
         this.status = status;
     }
 
+    public boolean isEnded() {
+        return this.status == StudyStatus.ENDED;
+    }
+
     @Builder
     public Study(String name, String description, LocalDate startDate, LocalDate endDate, StudyStatus status,
                  Boolean isDeleted, Long teamId, Long cropId, List<CurriculumItem> curriculumItems) {

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -97,4 +97,8 @@ public class Study extends BaseEntity {
     public void terminate() {
         this.status = ENDED;
     }
+
+    public void changeStatus(StudyStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -56,16 +56,11 @@ public class Study extends BaseEntity {
     private Long cropId;
 
     @OneToMany(mappedBy = "study")
-    private List<CurriculumItem> curriculumItems;
+    private final List<CurriculumItem> curriculumItems = new ArrayList<>();
 
 
     public void createCurriculumItems(List<CurriculumItem> newCurriculumItems) {
-        if (curriculumItems == null) {
-            return;
-        }
-        newCurriculumItems.forEach(newCurriculumItem -> {
-            newCurriculumItem.saveStudyToCurriculum(this);
-        });
+        newCurriculumItems.forEach(newCurriculumItem -> newCurriculumItem.saveStudyToCurriculum(this));
         curriculumItems.addAll(newCurriculumItems);
     }
 
@@ -92,8 +87,7 @@ public class Study extends BaseEntity {
         this.isDeleted = isDeleted;
         this.teamId = teamId;
         this.cropId = cropId;
-        this.curriculumItems = (curriculumItems != null) ? curriculumItems : new ArrayList<>();
-        ;
+        this.curriculumItems.addAll(curriculumItems);
     }
 
     public void terminate() {

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -64,7 +64,7 @@ public class Study extends BaseEntity {
             return;
         }
         newCurriculumItems.forEach(newCurriculumItem -> {
-            newCurriculumItem.setStudy(this);
+            newCurriculumItem.saveStudyToCurriculum(this);
         });
         curriculumItems.addAll(newCurriculumItems);
     }

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -1,6 +1,7 @@
 package doore.study.domain;
 
 import doore.base.BaseEntity;
+import doore.study.application.dto.request.StudyUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,15 +11,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Study extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,7 +39,7 @@ public class Study extends BaseEntity {
     private LocalDate startDate;
 
     @Column
-    private LocalDate endTime;
+    private LocalDate endDate;
 
     @Column
     @Enumerated(EnumType.STRING)
@@ -51,4 +57,37 @@ public class Study extends BaseEntity {
     @OneToMany(mappedBy = "study")
     private List<CurriculumItem> curriculumItems;
 
+
+    public void createCurriculumItems(List<CurriculumItem> newCurriculumItems) {
+        if (curriculumItems == null) {
+            return;
+        }
+        newCurriculumItems.forEach(newCurriculumItem -> {
+            newCurriculumItem.setStudy(this);
+        });
+        curriculumItems.addAll(newCurriculumItems);
+    }
+
+    public void update(StudyUpdateRequest studyUpdateRequest) {
+        this.name = studyUpdateRequest.name();
+        this.description = studyUpdateRequest.description();
+        this.startDate = studyUpdateRequest.startDate();
+        this.endDate = studyUpdateRequest.endDate();
+        this.status = studyUpdateRequest.status();
+    }
+
+    @Builder
+    public Study(String name, String description, LocalDate startDate, LocalDate endDate, StudyStatus status,
+                 Boolean isDeleted, Long teamId, Long cropId, List<CurriculumItem> curriculumItems) {
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+        this.isDeleted = isDeleted;
+        this.teamId = teamId;
+        this.cropId = cropId;
+        this.curriculumItems = (curriculumItems != null) ? curriculumItems : new ArrayList<>();
+        ;
+    }
 }

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -13,18 +13,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Study extends BaseEntity {
 
@@ -62,7 +58,7 @@ public class Study extends BaseEntity {
 
 
     public void createCurriculumItems(List<CurriculumItem> newCurriculumItems) {
-        newCurriculumItems.forEach(newCurriculumItem -> newCurriculumItem.saveStudyToCurriculum(this));
+        newCurriculumItems.forEach(newCurriculumItem -> newCurriculumItem.saveStudy(this));
         curriculumItems.addAll(newCurriculumItems);
     }
 
@@ -74,12 +70,8 @@ public class Study extends BaseEntity {
         this.status = status;
     }
 
-    public boolean isEnded() {
-        return this.status == ENDED;
-    }
-
     @Builder
-    public Study(String name, String description, LocalDate startDate, LocalDate endDate, StudyStatus status,
+    private Study(String name, String description, LocalDate startDate, LocalDate endDate, StudyStatus status,
                  Boolean isDeleted, Long teamId, Long cropId, List<CurriculumItem> curriculumItems) {
         this.name = name;
         this.description = description;

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -57,19 +57,6 @@ public class Study extends BaseEntity {
     private final List<CurriculumItem> curriculumItems = new ArrayList<>();
 
 
-    public void createCurriculumItems(List<CurriculumItem> newCurriculumItems) {
-        newCurriculumItems.forEach(newCurriculumItem -> newCurriculumItem.saveStudy(this));
-        curriculumItems.addAll(newCurriculumItems);
-    }
-
-    public void update(String name, String description, LocalDate startDate, LocalDate endDate, StudyStatus status) {
-        this.name = name;
-        this.description = description;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.status = status;
-    }
-
     @Builder
     private Study(String name, String description, LocalDate startDate, LocalDate endDate, StudyStatus status,
                  Boolean isDeleted, Long teamId, Long cropId, List<CurriculumItem> curriculumItems) {
@@ -84,6 +71,19 @@ public class Study extends BaseEntity {
         if (curriculumItems != null) {
             this.curriculumItems.addAll(curriculumItems);
         }
+    }
+
+    public void createCurriculumItems(List<CurriculumItem> newCurriculumItems) {
+        newCurriculumItems.forEach(newCurriculumItem -> newCurriculumItem.saveStudy(this));
+        curriculumItems.addAll(newCurriculumItems);
+    }
+
+    public void update(String name, String description, LocalDate startDate, LocalDate endDate, StudyStatus status) {
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
     }
 
     public void terminate() {

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -1,7 +1,6 @@
 package doore.study.domain;
 
 import doore.base.BaseEntity;
-import doore.study.application.dto.request.StudyUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -68,12 +67,12 @@ public class Study extends BaseEntity {
         curriculumItems.addAll(newCurriculumItems);
     }
 
-    public void update(StudyUpdateRequest studyUpdateRequest) {
-        this.name = studyUpdateRequest.name();
-        this.description = studyUpdateRequest.description();
-        this.startDate = studyUpdateRequest.startDate();
-        this.endDate = studyUpdateRequest.endDate();
-        this.status = studyUpdateRequest.status();
+    public void update(String name, String description, LocalDate startDate, LocalDate endDate, StudyStatus status) {
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
     }
 
     @Builder

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -13,6 +13,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -87,7 +89,9 @@ public class Study extends BaseEntity {
         this.isDeleted = isDeleted;
         this.teamId = teamId;
         this.cropId = cropId;
-        this.curriculumItems.addAll(curriculumItems);
+        if (curriculumItems != null) {
+            this.curriculumItems.addAll(curriculumItems);
+        }
     }
 
     public void terminate() {

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -1,5 +1,7 @@
 package doore.study.domain;
 
+import static doore.study.domain.StudyStatus.ENDED;
+
 import doore.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -76,7 +78,7 @@ public class Study extends BaseEntity {
     }
 
     public boolean isEnded() {
-        return this.status == StudyStatus.ENDED;
+        return this.status == ENDED;
     }
 
     @Builder
@@ -92,5 +94,9 @@ public class Study extends BaseEntity {
         this.cropId = cropId;
         this.curriculumItems = (curriculumItems != null) ? curriculumItems : new ArrayList<>();
         ;
+    }
+
+    public void terminate() {
+        this.status = ENDED;
     }
 }

--- a/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
+++ b/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
@@ -1,0 +1,7 @@
+package doore.study.domain.repository;
+
+import doore.study.domain.CurriculumItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CurriculumItemRepository extends JpaRepository<CurriculumItem,Long> {
+}

--- a/src/main/java/doore/study/domain/repository/StudyRepository.java
+++ b/src/main/java/doore/study/domain/repository/StudyRepository.java
@@ -1,0 +1,7 @@
+package doore.study.domain.repository;
+
+import doore.study.domain.Study;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyRepository extends JpaRepository<Study, Long> {
+}

--- a/src/main/java/doore/study/exception/StudyException.java
+++ b/src/main/java/doore/study/exception/StudyException.java
@@ -1,0 +1,18 @@
+package doore.study.exception;
+
+import doore.base.BaseException;
+import doore.base.BaseExceptionType;
+
+public class StudyException extends BaseException {
+    StudyExceptionType exceptionType;
+
+    public StudyException(final StudyExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/doore/study/exception/StudyException.java
+++ b/src/main/java/doore/study/exception/StudyException.java
@@ -4,7 +4,7 @@ import doore.base.BaseException;
 import doore.base.BaseExceptionType;
 
 public class StudyException extends BaseException {
-    StudyExceptionType exceptionType;
+    private final StudyExceptionType exceptionType;
 
     public StudyException(final StudyExceptionType exceptionType) {
         super(exceptionType.errorMessage());

--- a/src/main/java/doore/study/exception/StudyExceptionType.java
+++ b/src/main/java/doore/study/exception/StudyExceptionType.java
@@ -1,0 +1,26 @@
+package doore.study.exception;
+
+import doore.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum StudyExceptionType implements BaseExceptionType {
+    NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
+    TERMINATED_STUDY(HttpStatus.FORBIDDEN, "이미 종료된 스터디입니다.");
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    StudyExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/doore/study/exception/StudyExceptionType.java
+++ b/src/main/java/doore/study/exception/StudyExceptionType.java
@@ -6,8 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum StudyExceptionType implements BaseExceptionType {
     NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
     NOT_FOUND_STATUS(HttpStatus.BAD_REQUEST, "존재하지 않는 스터디 상태입니다."),
-    INVALID_ENDDATE(HttpStatus.BAD_REQUEST, "시작일보다 빠른 날짜에 종료할 수 없습니다."),
-    ALREADY_TERMINATED_STUDY(HttpStatus.FORBIDDEN, "이미 종료된 스터디입니다.");
+    INVALID_ENDDATE(HttpStatus.BAD_REQUEST, "시작일보다 빠른 날짜에 종료할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/doore/study/exception/StudyExceptionType.java
+++ b/src/main/java/doore/study/exception/StudyExceptionType.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum StudyExceptionType implements BaseExceptionType {
     NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
-    TERMINATED_STUDY(HttpStatus.FORBIDDEN, "이미 종료된 스터디입니다.");
+    ALREADY_TERMINATED_STUDY(HttpStatus.FORBIDDEN, "이미 종료된 스터디입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/doore/study/exception/StudyExceptionType.java
+++ b/src/main/java/doore/study/exception/StudyExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum StudyExceptionType implements BaseExceptionType {
     NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
     NOT_FOUND_STATUS(HttpStatus.BAD_REQUEST, "존재하지 않는 스터디 상태입니다."),
+    INVALID_ENDDATE(HttpStatus.BAD_REQUEST, "시작일보다 빠른 날짜에 종료할 수 없습니다."),
     ALREADY_TERMINATED_STUDY(HttpStatus.FORBIDDEN, "이미 종료된 스터디입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/study/exception/StudyExceptionType.java
+++ b/src/main/java/doore/study/exception/StudyExceptionType.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum StudyExceptionType implements BaseExceptionType {
     NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
+    NOT_FOUND_STATUS(HttpStatus.BAD_REQUEST, "존재하지 않는 스터디 상태입니다."),
     ALREADY_TERMINATED_STUDY(HttpStatus.FORBIDDEN, "이미 종료된 스터디입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/study/exception/StudyExceptionType.java
+++ b/src/main/java/doore/study/exception/StudyExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum StudyExceptionType implements BaseExceptionType {
     NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
     TERMINATED_STUDY(HttpStatus.FORBIDDEN, "이미 종료된 스터디입니다.");
+
     private final HttpStatus httpStatus;
     private final String errorMessage;
 

--- a/src/test/java/doore/helper/IntegrationTest.java
+++ b/src/test/java/doore/helper/IntegrationTest.java
@@ -4,6 +4,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +51,11 @@ public abstract class IntegrationTest {
         return mockMvc.perform(get(url));
     }
 
+    protected ResultActions callPutApi(final String url, final Object value) throws Exception {
+        return mockMvc.perform(put(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(value)));
+    }
     protected ResultActions callPatchApi(final String url, final Object value) throws Exception {
         return mockMvc.perform(patch(url)
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/doore/helper/IntegrationTest.java
+++ b/src/test/java/doore/helper/IntegrationTest.java
@@ -1,6 +1,9 @@
 package doore.helper;
 
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +38,20 @@ public abstract class IntegrationTest {
 
     protected ResultActions callPostApi(final String url, final Object value) throws Exception {
         return mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(value)));
+    }
+
+    protected ResultActions callDeleteApi(final String url) throws Exception {
+        return mockMvc.perform(delete(url));
+    }
+
+    protected ResultActions callGetApi(final String url) throws Exception {
+        return mockMvc.perform(get(url));
+    }
+
+    protected ResultActions callPatchApi(final String url, final Object value) throws Exception {
+        return mockMvc.perform(patch(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(value)));
     }

--- a/src/test/java/doore/restdocs/RestDocsTest.java
+++ b/src/test/java/doore/restdocs/RestDocsTest.java
@@ -74,15 +74,15 @@ public abstract class RestDocsTest {
                 .content(objectMapper.writeValueAsString(value)));
     }
 
-    protected ResultActions callPostApi(final String url) throws Exception {
-        return mockMvc.perform(post(url)
-                .contentType(MediaType.APPLICATION_JSON));
-    }
-
     protected ResultActions callPatchApi(final String url, final Object value) throws Exception {
         return mockMvc.perform(patch(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(value)));
+    }
+
+    protected ResultActions callPatchApi(final String url) throws Exception {
+        return mockMvc.perform(patch(url)
+                .contentType(MediaType.APPLICATION_JSON));
     }
 
     protected ResultActions callGetApi(final String url) throws Exception {

--- a/src/test/java/doore/restdocs/RestDocsTest.java
+++ b/src/test/java/doore/restdocs/RestDocsTest.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,6 +84,12 @@ public abstract class RestDocsTest {
     protected ResultActions callPatchApi(final String url) throws Exception {
         return mockMvc.perform(patch(url)
                 .contentType(MediaType.APPLICATION_JSON));
+    }
+
+    protected ResultActions callPutApi(final String url, final Object value) throws Exception {
+        return mockMvc.perform(put(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(value)));
     }
 
     protected ResultActions callGetApi(final String url) throws Exception {

--- a/src/test/java/doore/restdocs/RestDocsTest.java
+++ b/src/test/java/doore/restdocs/RestDocsTest.java
@@ -1,8 +1,11 @@
 package doore.restdocs;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,9 +58,38 @@ public abstract class RestDocsTest {
                 .description(description);
     }
 
+    protected FieldDescriptor booleanFieldWithPath(final String path, final String description) {
+        return fieldWithPath(path).type(JsonFieldType.BOOLEAN)
+                .description(description);
+    }
+
+    protected FieldDescriptor arrayFieldWithPath(final String path, final String description) {
+        return fieldWithPath(path).type(JsonFieldType.ARRAY)
+                .description(description);
+    }
+
     protected ResultActions callPostApi(final String url, final Object value) throws Exception {
         return mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(value)));
+    }
+
+    protected ResultActions callPostApi(final String url) throws Exception {
+        return mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON));
+    }
+
+    protected ResultActions callPatchApi(final String url, final Object value) throws Exception {
+        return mockMvc.perform(patch(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(value)));
+    }
+
+    protected ResultActions callGetApi(final String url) throws Exception {
+        return mockMvc.perform(get(url));
+    }
+
+    protected ResultActions callDeleteApi(final String url) throws Exception {
+        return mockMvc.perform(delete(url));
     }
 }

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -43,8 +43,6 @@ public class StudyApiDocsTest extends RestDocsTest {
                         stringFieldWithPath("description", "스터디 설명"),
                         stringFieldWithPath("startDate", "시작 날짜"),
                         stringFieldWithPath("endDate", "종료 날짜"),
-                        stringFieldWithPath("status", "현재 상태"),
-                        booleanFieldWithPath("isDeleted", "삭제 여부"),
                         numberFieldWithPath("cropId", "작물 id"),
                         arrayFieldWithPath("curriculumItems", "커리큘럼 아이템 리스트")
                 )));

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -76,8 +76,8 @@ public class StudyApiDocsTest extends RestDocsTest {
         Study study = mock(Study.class);
         studyRepository.save(study);
         StudyUpdateRequest request = studyUpdateRequest();
-        callPatchApi("/studies/1", request)
-                .andExpect(status().isNoContent())
+        callPutApi("/studies/1", request)
+                .andExpect(status().isOk())
                 .andDo(document("study-update", requestFields(
                         stringFieldWithPath("name", "스터디 이름"),
                         stringFieldWithPath("description", "스터디 설명"),

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -1,0 +1,97 @@
+package doore.restdocs.docs;
+
+import static doore.study.StudyFixture.algorithm_study;
+import static doore.study.StudyFixture.studyCreateRequest;
+import static doore.study.StudyFixture.studyUpdateRequest;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+
+import doore.study.application.dto.request.StudyUpdateRequest;
+import doore.study.domain.Study;
+import doore.study.domain.repository.StudyRepository;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import doore.restdocs.RestDocsTest;
+import doore.study.api.StudyController;
+import doore.study.application.StudyService;
+import doore.study.application.dto.request.StudyCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(StudyController.class)
+public class StudyApiDocsTest extends RestDocsTest {
+    @MockBean
+    protected StudyService studyService;
+
+    @MockBean
+    protected StudyRepository studyRepository;
+
+    @Test
+    @DisplayName("스터디를 생성한다.")
+    public void 스터디를_생성한다() throws Exception {
+        StudyCreateRequest request = studyCreateRequest();
+        callPostApi("/teams/1/studies", request)
+                .andExpect(status().isCreated())
+                .andDo(document("study-create", requestFields(
+                        stringFieldWithPath("name", "스터디 이름"),
+                        stringFieldWithPath("description", "스터디 설명"),
+                        stringFieldWithPath("startDate", "시작 날짜"),
+                        stringFieldWithPath("endDate", "종료 날짜"),
+                        stringFieldWithPath("status", "현재 상태"),
+                        booleanFieldWithPath("isDeleted", "삭제 여부"),
+                        numberFieldWithPath("cropId", "작물 id"),
+                        arrayFieldWithPath("curriculumItems", "커리큘럼 아이템 리스트")
+                )));
+    }
+
+    @Test
+    @DisplayName("스터디를 조회한다.")
+    public void 스터디를_조회한다() throws Exception {
+        Study study = algorithm_study();
+        studyRepository.save(study);
+        callGetApi("/studies/1")
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("study-get"));
+    }
+
+
+    @Test
+    @DisplayName("스터디를 삭제한다.")
+    public void 스터디를_삭제한다() throws Exception {
+        Study study = algorithm_study();
+        studyRepository.save(study);
+        callDeleteApi("/studies/1")
+                .andExpect(status().isNoContent())
+                .andDo(document("study-delete"));
+    }
+
+    @Test
+    @DisplayName("스터디를 수정한다.")
+    public void 스터디를_수정한다() throws Exception {
+        Study study = algorithm_study();
+        studyRepository.save(study);
+        StudyUpdateRequest request = studyUpdateRequest();
+        callPatchApi("/studies/1", request)
+                .andExpect(status().isNoContent())
+                .andDo(document("study-update", requestFields(
+                        stringFieldWithPath("name", "스터디 이름"),
+                        stringFieldWithPath("description", "스터디 설명"),
+                        stringFieldWithPath("startDate", "시작 날짜"),
+                        stringFieldWithPath("endDate", "종료 날짜"),
+                        stringFieldWithPath("status", "현재 상태")
+                )));
+    }
+
+    @Test
+    @DisplayName("스터디를 종료한다.")
+    public void 스터디를_종료한다() throws Exception {
+        Study study = algorithm_study();
+        studyRepository.save(study);
+        callPostApi("/studies/1/termination")
+                .andExpect(status().isOk())
+                .andDo(document("study-terminate"));
+    }
+}

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -90,8 +90,8 @@ public class StudyApiDocsTest extends RestDocsTest {
     public void 스터디를_종료한다() throws Exception {
         Study study = algorithm_study();
         studyRepository.save(study);
-        callPostApi("/studies/1/termination")
-                .andExpect(status().isOk())
+        callPatchApi("/studies/1/termination")
+                .andExpect(status().isNoContent())
                 .andDo(document("study-terminate"));
     }
 }

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -1,8 +1,8 @@
 package doore.restdocs.docs;
 
-import static doore.study.StudyFixture.algorithm_study;
 import static doore.study.StudyFixture.studyCreateRequest;
 import static doore.study.StudyFixture.studyUpdateRequest;
+import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -49,7 +49,7 @@ public class StudyApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("스터디를 조회한다.")
     public void 스터디를_조회한다() throws Exception {
-        Study study = algorithm_study();
+        Study study = mock(Study.class);
         studyRepository.save(study);
         callGetApi("/studies/1")
                 .andExpect(status().isOk())
@@ -61,7 +61,7 @@ public class StudyApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("스터디를 삭제한다.")
     public void 스터디를_삭제한다() throws Exception {
-        Study study = algorithm_study();
+        Study study = mock(Study.class);
         studyRepository.save(study);
         callDeleteApi("/studies/1")
                 .andExpect(status().isNoContent())
@@ -71,7 +71,7 @@ public class StudyApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("스터디를 수정한다.")
     public void 스터디를_수정한다() throws Exception {
-        Study study = algorithm_study();
+        Study study = mock(Study.class);
         studyRepository.save(study);
         StudyUpdateRequest request = studyUpdateRequest();
         callPatchApi("/studies/1", request)
@@ -88,7 +88,7 @@ public class StudyApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("스터디를 종료한다.")
     public void 스터디를_종료한다() throws Exception {
-        Study study = algorithm_study();
+        Study study = mock(Study.class);
         studyRepository.save(study);
         callPatchApi("/studies/1/termination")
                 .andExpect(status().isNoContent())

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -88,6 +88,16 @@ public class StudyApiDocsTest extends RestDocsTest {
     }
 
     @Test
+    @DisplayName("스터디의 상태를 수정한다.")
+    public void 스터디의_상태를_수정한다() throws Exception {
+        Study study = mock(Study.class);
+        studyRepository.save(study);
+        callPatchApi("/studies/1/status?status=IN_PROGRESS")
+                .andExpect(status().isNoContent())
+                .andDo(document("study-change-status"));
+    }
+
+    @Test
     @DisplayName("스터디를 종료한다.")
     public void 스터디를_종료한다() throws Exception {
         Study study = mock(Study.class);

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -8,13 +8,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 
+import doore.study.application.StudyCommandService;
+import doore.study.application.StudyQueryService;
 import doore.study.application.dto.request.StudyUpdateRequest;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import doore.restdocs.RestDocsTest;
 import doore.study.api.StudyController;
-import doore.study.application.StudyService;
 import doore.study.application.dto.request.StudyCreateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @WebMvcTest(StudyController.class)
 public class StudyApiDocsTest extends RestDocsTest {
     @MockBean
-    protected StudyService studyService;
+    protected StudyCommandService studyCommandService;
+
+    @MockBean
+    protected StudyQueryService studyQueryService;
 
     @MockBean
     protected StudyRepository studyRepository;

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -1,7 +1,5 @@
 package doore.restdocs.docs;
 
-import static doore.study.StudyFixture.studyCreateRequest;
-import static doore.study.StudyFixture.studyUpdateRequest;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -10,9 +8,13 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 
 import doore.study.application.StudyCommandService;
 import doore.study.application.StudyQueryService;
+import doore.study.application.dto.request.CurriculumItemsRequest;
 import doore.study.application.dto.request.StudyUpdateRequest;
 import doore.study.domain.Study;
+import doore.study.domain.StudyStatus;
 import doore.study.domain.repository.StudyRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import doore.restdocs.RestDocsTest;
 import doore.study.api.StudyController;
@@ -35,7 +37,14 @@ public class StudyApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("스터디를 생성한다.")
     public void 스터디를_생성한다() throws Exception {
-        StudyCreateRequest request = studyCreateRequest();
+        StudyCreateRequest request = StudyCreateRequest.builder()
+                .name("알고리즘")
+                .description("알고리즘 스터디 입니다.")
+                .startDate(LocalDate.parse("2023-01-01"))
+                .endDate(LocalDate.parse("2024-01-01"))
+                .cropId(1L)
+                .curriculumItems(new ArrayList<CurriculumItemsRequest>())
+                .build();
         callPostApi("/teams/1/studies", request)
                 .andExpect(status().isCreated())
                 .andDo(document("study-create", requestFields(
@@ -75,7 +84,13 @@ public class StudyApiDocsTest extends RestDocsTest {
     public void 스터디를_수정한다() throws Exception {
         Study study = mock(Study.class);
         studyRepository.save(study);
-        StudyUpdateRequest request = studyUpdateRequest();
+        StudyUpdateRequest request = StudyUpdateRequest.builder()
+                .name("스프링")
+                .description("스프링 스터디 입니다.")
+                .startDate(LocalDate.parse("2023-01-01"))
+                .endDate(LocalDate.parse("2024-01-01"))
+                .status(StudyStatus.IN_PROGRESS)
+                .build();
         callPutApi("/studies/1", request)
                 .andExpect(status().isOk())
                 .andDo(document("study-update", requestFields(

--- a/src/test/java/doore/study/StudyFixture.java
+++ b/src/test/java/doore/study/StudyFixture.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 
 public class StudyFixture {
-    public static Study algorithm_study() {
+    public static Study algorithmStudy() {
         return Study.builder()
                 .name("알고리즘")
                 .description("알고리즘 스터디 입니다.")
@@ -21,27 +21,6 @@ public class StudyFixture {
                 .isDeleted(false)
                 .cropId(1L)
                 .curriculumItems(new ArrayList<CurriculumItem>())
-                .build();
-    }
-
-    public static StudyCreateRequest studyCreateRequest() {
-        return StudyCreateRequest.builder()
-                .name("알고리즘")
-                .description("알고리즘 스터디 입니다.")
-                .startDate(LocalDate.parse("2023-01-01"))
-                .endDate(LocalDate.parse("2024-01-01"))
-                .cropId(1L)
-                .curriculumItems(new ArrayList<CurriculumItemsRequest>())
-                .build();
-    }
-
-    public static StudyUpdateRequest studyUpdateRequest() {
-        return StudyUpdateRequest.builder()
-                .name("스프링")
-                .description("스프링 스터디 입니다.")
-                .startDate(LocalDate.parse("2023-01-01"))
-                .endDate(LocalDate.parse("2024-01-01"))
-                .status(StudyStatus.IN_PROGRESS)
                 .build();
     }
 }

--- a/src/test/java/doore/study/StudyFixture.java
+++ b/src/test/java/doore/study/StudyFixture.java
@@ -30,8 +30,6 @@ public class StudyFixture {
                 .description("알고리즘 스터디 입니다.")
                 .startDate(LocalDate.parse("2023-01-01"))
                 .endDate(LocalDate.parse("2024-01-01"))
-                .status(StudyStatus.IN_PROGRESS)
-                .isDeleted(false)
                 .cropId(1L)
                 .curriculumItems(new ArrayList<CurriculumItemsRequest>())
                 .build();

--- a/src/test/java/doore/study/StudyFixture.java
+++ b/src/test/java/doore/study/StudyFixture.java
@@ -1,0 +1,49 @@
+package doore.study;
+
+import doore.study.application.dto.request.CurriculumItemsRequest;
+import doore.study.application.dto.request.StudyCreateRequest;
+import doore.study.application.dto.request.StudyUpdateRequest;
+import doore.study.domain.CurriculumItem;
+import doore.study.domain.Study;
+import doore.study.domain.StudyStatus;
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+public class StudyFixture {
+    public static Study algorithm_study() {
+        return Study.builder()
+                .name("알고리즘")
+                .description("알고리즘 스터디 입니다.")
+                .startDate(LocalDate.parse("2023-01-01"))
+                .endDate(LocalDate.parse("2024-01-01"))
+                .teamId(1L)
+                .status(StudyStatus.IN_PROGRESS)
+                .isDeleted(false)
+                .cropId(1L)
+                .curriculumItems(new ArrayList<CurriculumItem>())
+                .build();
+    }
+
+    public static StudyCreateRequest studyCreateRequest() {
+        return StudyCreateRequest.builder()
+                .name("알고리즘")
+                .description("알고리즘 스터디 입니다.")
+                .startDate(LocalDate.parse("2023-01-01"))
+                .endDate(LocalDate.parse("2024-01-01"))
+                .status(StudyStatus.IN_PROGRESS)
+                .isDeleted(false)
+                .cropId(1L)
+                .curriculumItems(new ArrayList<CurriculumItemsRequest>())
+                .build();
+    }
+
+    public static StudyUpdateRequest studyUpdateRequest() {
+        return StudyUpdateRequest.builder()
+                .name("스프링")
+                .description("스프링 스터디 입니다.")
+                .startDate(LocalDate.parse("2023-01-01"))
+                .endDate(LocalDate.parse("2024-01-01"))
+                .status(StudyStatus.IN_PROGRESS)
+                .build();
+    }
+}

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -1,6 +1,6 @@
 package doore.study.api;
 
-import static doore.study.StudyFixture.algorithm_study;
+import static doore.study.StudyFixture.algorithmStudy;
 import static doore.team.TeamFixture.team;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.mockito.Mockito.mock;
@@ -70,7 +70,7 @@ public class StudyControllerTest extends IntegrationTest {
     @Test
     @DisplayName("정상적으로 스터디를 조회한다.")
     void 정상적으로_스터디를_조회한다_성공() throws Exception {
-        final Study study = algorithm_study();
+        final Study study = algorithmStudy();
         studyRepository.save(study);
         String url = "/studies/" + study.getId();
         callGetApi(url).andExpect(status().isOk());
@@ -79,7 +79,7 @@ public class StudyControllerTest extends IntegrationTest {
     @Test
     @DisplayName("정상적으로 스터디를 수정한다.")
     void 정상적으로_스터디를_수정한다_성공() throws Exception {
-        final Study study = algorithm_study();
+        final Study study = algorithmStudy();
         studyRepository.save(study);
         study.update("스프링 스터디",study.getDescription(),study.getStartDate(),study.getEndDate(),study.getStatus());
         String url = "/studies/" + study.getId();
@@ -89,7 +89,7 @@ public class StudyControllerTest extends IntegrationTest {
     @Test
     @DisplayName("정상적으로 스터디의 상태를 변경한다.")
     void 정상적으로_스터디의_상태를_변경한다_성공() throws Exception {
-        final Study study = algorithm_study();
+        final Study study = algorithmStudy();
         studyRepository.save(study);
         String url = "/studies/" + study.getId() + "/status?status=IN_PROGRESS";
         callPatchApi(url, study).andExpect(status().isNoContent());
@@ -98,7 +98,7 @@ public class StudyControllerTest extends IntegrationTest {
     @Test
     @DisplayName("정상적으로 스터디를 종료한다.")
     void 정상적으로_스터디를_종료한다_성공() throws Exception {
-        final Study study = algorithm_study();
+        final Study study = algorithmStudy();
         studyRepository.save(study);
         String url = "/studies/" + study.getId() + "/termination";
         callPatchApi(url, study).andExpect(status().isNoContent());

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -1,0 +1,102 @@
+package doore.study.api;
+
+import static doore.study.StudyFixture.algorithm_study;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.mock;
+
+import doore.helper.IntegrationTest;
+import doore.study.application.dto.request.StudyCreateRequest;
+import doore.study.domain.Study;
+import doore.study.domain.StudyStatus;
+import doore.study.domain.repository.StudyRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class StudyControllerTest extends IntegrationTest {
+    @Autowired
+    private StudyRepository studyRepository;
+
+    @Nested
+    @DisplayName("스터디 생성 테스트")
+    class StudyCreateTest {
+        @Test
+        @DisplayName("정상적으로 스터디를 생성한다.")
+        void 정상적으로_스터디를_생성한다_성공() throws Exception {
+            final StudyCreateRequest request = new StudyCreateRequest("알고리즘", "알고리즘 스터디 입니다.",
+                    LocalDate.parse("2020-01-01"), LocalDate.parse("2020-01-05"),
+                    StudyStatus.IN_PROGRESS, false, 1L, null);
+
+            callPostApi("/teams/1/studies", request).andExpect(status().isCreated());
+        }
+
+        @ParameterizedTest
+        @DisplayName("필수값이 입력되지 않은 경우 스터디 생성에 실패한다.")
+        @CsvSource({
+                ", 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, IN_PROGRESS, false, 1",
+                "알고리즘, , 2022-01-01, 2022-01-05, IN_PROGRESS, false, 1",
+                "알고리즘, 알고리즘 스터디입니다., , 2022-01-05, IN_PROGRESS, false, 1",
+                "알고리즘, 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, , false, 1",
+                "알고리즘, 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, IN_PROGRESS, , 1",
+                "알고리즘, 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, IN_PROGRESS, false, "
+        })
+        void 필수값이_입력되지_않은_경우_스터디_생성에_실패한다_실패(String name, String description, String startDate, String endDate,
+                                             String status, Boolean isDeleted, Long cropId)
+                throws Exception {
+            final StudyCreateRequest request = new StudyCreateRequest(
+                    name, description, (startDate != null && !startDate.isEmpty()) ? LocalDate.parse(startDate) : null,
+                    LocalDate.parse(endDate),
+                    (status != null && !status.isEmpty()) ? StudyStatus.valueOf(status) : null, isDeleted, cropId, null
+            );
+
+            callPostApi("/teams/1/studies", request).andExpect(status().isBadRequest());
+        }
+    }
+
+
+    @Test
+    @DisplayName("정상적으로 스터디를 삭제한다.")
+    void 정상적으로_스터디를_삭제한다_성공() throws Exception {
+        final Study study = mock(Study.class);
+        String url = "/studies/" + study.getId();
+        callDeleteApi(url).andExpect(status().isNoContent());
+    }
+
+
+    @Test
+    @DisplayName("정상적으로 스터디를 조회한다.")
+    void 정상적으로_스터디를_조회한다_성공() throws Exception {
+        final Study study = algorithm_study();
+        studyRepository.save(study);
+        String url = "/studies/" + study.getId();
+        callGetApi(url).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("정상적으로 스터디를 수정한다.")
+    void 정상적으로_스터디를_수정한다_성공() throws Exception {
+        final Study study = algorithm_study();
+        studyRepository.save(study);
+        study.setName("스프링 스터디");
+        String url = "/studies/" + study.getId();
+        callPatchApi(url, study).andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("정상적으로 스터디를 종료한다.")
+    void 정상적으로_스터디를_종료한다_성공() throws Exception {
+        final Study study = algorithm_study();
+        studyRepository.save(study);
+        String url = "/studies/" + study.getId() + "/termination";
+        callPostApi(url, study).andExpect(status().isOk());
+    }
+
+}

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.mock;
 import doore.helper.IntegrationTest;
 import doore.study.application.dto.request.StudyCreateRequest;
 import doore.study.domain.Study;
-import doore.study.domain.StudyStatus;
 import doore.study.domain.repository.StudyRepository;
 import doore.team.domain.Team;
 import doore.team.domain.TeamRepository;
@@ -37,7 +36,6 @@ public class StudyControllerTest extends IntegrationTest {
             String url = "/teams/" + team.getId() + "/studies";
             final StudyCreateRequest request = new StudyCreateRequest("알고리즘", "알고리즘 스터디 입니다.",
                     LocalDate.parse("2020-01-01"), LocalDate.parse("2020-01-05"), 1L, null);
-
             callPostApi(url, request).andExpect(status().isCreated());
         }
 
@@ -85,7 +83,7 @@ public class StudyControllerTest extends IntegrationTest {
         studyRepository.save(study);
         study.setName("스프링 스터디");
         String url = "/studies/" + study.getId();
-        callPatchApi(url, study).andExpect(status().isNoContent());
+        callPutApi(url, study).andExpect(status().isOk());
     }
 
     @Test

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -36,8 +36,7 @@ public class StudyControllerTest extends IntegrationTest {
             teamRepository.save(team);
             String url = "/teams/" + team.getId() + "/studies";
             final StudyCreateRequest request = new StudyCreateRequest("알고리즘", "알고리즘 스터디 입니다.",
-                    LocalDate.parse("2020-01-01"), LocalDate.parse("2020-01-05"),
-                    StudyStatus.IN_PROGRESS, false, 1L, null);
+                    LocalDate.parse("2020-01-01"), LocalDate.parse("2020-01-05"), 1L, null);
 
             callPostApi(url, request).andExpect(status().isCreated());
         }
@@ -45,21 +44,16 @@ public class StudyControllerTest extends IntegrationTest {
         @ParameterizedTest
         @DisplayName("필수값이 입력되지 않은 경우 스터디 생성에 실패한다.")
         @CsvSource({
-                ", 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, IN_PROGRESS, false, 1",
-                "알고리즘, , 2022-01-01, 2022-01-05, IN_PROGRESS, false, 1",
-                "알고리즘, 알고리즘 스터디입니다., , 2022-01-05, IN_PROGRESS, false, 1",
-                "알고리즘, 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, , false, 1",
-                "알고리즘, 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, IN_PROGRESS, , 1",
-                "알고리즘, 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, IN_PROGRESS, false, "
+                ", 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, 1",
+                "알고리즘, , 2022-01-01, 2022-01-05, 1",
+                "알고리즘, 알고리즘 스터디입니다., , 2022-01-05, 1",
+                "알고리즘, 알고리즘 스터디입니다., 2022-01-01, 2022-01-05, "
         })
         void 필수값이_입력되지_않은_경우_스터디_생성에_실패한다_실패(String name, String description, String startDate, String endDate,
-                                             String status, Boolean isDeleted, Long cropId)
-                throws Exception {
-            final StudyCreateRequest request = new StudyCreateRequest(
-                    name, description, (startDate != null && !startDate.isEmpty()) ? LocalDate.parse(startDate) : null,
-                    LocalDate.parse(endDate),
-                    (status != null && !status.isEmpty()) ? StudyStatus.valueOf(status) : null, isDeleted, cropId, null
-            );
+                                             Long cropId) throws Exception {
+            final StudyCreateRequest request = new StudyCreateRequest(name, description,
+                    (startDate != null && !startDate.isEmpty()) ? LocalDate.parse(startDate) : null,
+                    LocalDate.parse(endDate), cropId, null);
 
             callPostApi("/teams/1/studies", request).andExpect(status().isBadRequest());
         }

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -81,7 +81,7 @@ public class StudyControllerTest extends IntegrationTest {
     void 정상적으로_스터디를_수정한다_성공() throws Exception {
         final Study study = algorithm_study();
         studyRepository.save(study);
-        study.setName("스프링 스터디");
+        study.update("스프링 스터디",study.getDescription(),study.getStartDate(),study.getEndDate(),study.getStatus());
         String url = "/studies/" + study.getId();
         callPutApi(url, study).andExpect(status().isOk());
     }

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -19,11 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-@AutoConfigureMockMvc
 public class StudyControllerTest extends IntegrationTest {
     @Autowired
     private StudyRepository studyRepository;

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -87,6 +87,15 @@ public class StudyControllerTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("정상적으로 스터디의 상태를 변경한다.")
+    void 정상적으로_스터디의_상태를_변경한다_성공() throws Exception {
+        final Study study = algorithm_study();
+        studyRepository.save(study);
+        String url = "/studies/" + study.getId() + "/status?status=IN_PROGRESS";
+        callPatchApi(url, study).andExpect(status().isNoContent());
+    }
+
+    @Test
     @DisplayName("정상적으로 스터디를 종료한다.")
     void 정상적으로_스터디를_종료한다_성공() throws Exception {
         final Study study = algorithm_study();

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -61,7 +61,8 @@ public class StudyControllerTest extends IntegrationTest {
     @Test
     @DisplayName("정상적으로 스터디를 삭제한다.")
     void 정상적으로_스터디를_삭제한다_성공() throws Exception {
-        final Study study = mock(Study.class);
+        final Study study = algorithmStudy();
+        studyRepository.save(study);
         String url = "/studies/" + study.getId();
         callDeleteApi(url).andExpect(status().isNoContent());
     }
@@ -81,7 +82,7 @@ public class StudyControllerTest extends IntegrationTest {
     void 정상적으로_스터디를_수정한다_성공() throws Exception {
         final Study study = algorithmStudy();
         studyRepository.save(study);
-        study.update("스프링 스터디",study.getDescription(),study.getStartDate(),study.getEndDate(),study.getStatus());
+        study.update("스프링 스터디", study.getDescription(), study.getStartDate(), study.getEndDate(), study.getStatus());
         String url = "/studies/" + study.getId();
         callPutApi(url, study).andExpect(status().isOk());
     }

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -1,6 +1,7 @@
 package doore.study.api;
 
 import static doore.study.StudyFixture.algorithm_study;
+import static doore.team.TeamFixture.team;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.mockito.Mockito.mock;
 
@@ -9,6 +10,8 @@ import doore.study.application.dto.request.StudyCreateRequest;
 import doore.study.domain.Study;
 import doore.study.domain.StudyStatus;
 import doore.study.domain.repository.StudyRepository;
+import doore.team.domain.Team;
+import doore.team.domain.TeamRepository;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,6 +27,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class StudyControllerTest extends IntegrationTest {
     @Autowired
     private StudyRepository studyRepository;
+    @Autowired
+    private TeamRepository teamRepository;
 
     @Nested
     @DisplayName("스터디 생성 테스트")
@@ -31,11 +36,14 @@ public class StudyControllerTest extends IntegrationTest {
         @Test
         @DisplayName("정상적으로 스터디를 생성한다.")
         void 정상적으로_스터디를_생성한다_성공() throws Exception {
+            final Team team = team();
+            teamRepository.save(team);
+            String url = "/teams/" + team.getId() + "/studies";
             final StudyCreateRequest request = new StudyCreateRequest("알고리즘", "알고리즘 스터디 입니다.",
                     LocalDate.parse("2020-01-01"), LocalDate.parse("2020-01-05"),
                     StudyStatus.IN_PROGRESS, false, 1L, null);
 
-            callPostApi("/teams/1/studies", request).andExpect(status().isCreated());
+            callPostApi(url, request).andExpect(status().isCreated());
         }
 
         @ParameterizedTest

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -96,7 +96,7 @@ public class StudyControllerTest extends IntegrationTest {
         final Study study = algorithm_study();
         studyRepository.save(study);
         String url = "/studies/" + study.getId() + "/termination";
-        callPostApi(url, study).andExpect(status().isOk());
+        callPatchApi(url, study).andExpect(status().isNoContent());
     }
 
 }

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -61,7 +61,7 @@ public class StudyServiceTest extends IntegrationTest {
         void 정상적으로_스터디를_조회할_수_있다_성공() throws Exception {
             Study study = algorithm_study();
             studyRepository.save(study);
-            assertEquals(study.getId(), studyService.findStudyById(study.getId()).getId());
+            assertEquals(study.getId(), studyService.findStudyById(study.getId()).id());
         }
 
         @Test

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -5,7 +5,7 @@ import static doore.study.StudyFixture.studyCreateRequest;
 import static doore.study.StudyFixture.studyUpdateRequest;
 import static doore.study.domain.StudyStatus.ENDED;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
-import static doore.study.exception.StudyExceptionType.TERMINATED_STUDY;
+import static doore.study.exception.StudyExceptionType.ALREADY_TERMINATED_STUDY;
 import static doore.team.TeamFixture.team;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -132,7 +132,7 @@ public class StudyServiceTest extends IntegrationTest {
 
             assertThatThrownBy(() -> studyCommandService.terminateStudy(study.getId()))
                     .isInstanceOf(StudyException.class)
-                    .hasMessage(TERMINATED_STUDY.errorMessage());
+                    .hasMessage(ALREADY_TERMINATED_STUDY.errorMessage());
 
         }
     }

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -1,0 +1,127 @@
+package doore.study.application;
+
+import static doore.study.StudyFixture.algorithm_study;
+import static doore.study.StudyFixture.studyCreateRequest;
+import static doore.study.StudyFixture.studyUpdateRequest;
+import static doore.study.domain.StudyStatus.ENDED;
+import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
+import static doore.study.exception.StudyExceptionType.TERMINATED_STUDY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import doore.helper.IntegrationTest;
+import doore.study.application.dto.request.StudyCreateRequest;
+import doore.study.application.dto.request.StudyUpdateRequest;
+import doore.study.domain.Study;
+import doore.study.domain.repository.StudyRepository;
+import doore.study.exception.StudyException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class StudyServiceTest extends IntegrationTest {
+    @Autowired
+    StudyService studyService;
+    @Autowired
+    StudyRepository studyRepository;
+
+    @Test
+    @DisplayName("정상적으로 스터디를 생성할 수 있다.")
+    void 정상적으로_스터디를_생성할_수_있다_성공() throws Exception {
+        StudyCreateRequest studyCreateRequest = studyCreateRequest();
+        studyService.createStudy(studyCreateRequest, 1L);
+
+        List<Study> studies = studyRepository.findAll();
+        assertThat(studies).hasSize(1);
+        Study study = studies.get(0);
+        assertEquals(study.getName(), studyCreateRequest.name());
+        assertEquals(study.getDescription(), studyCreateRequest.description());
+        assertEquals(study.getStartDate(), studyCreateRequest.startDate());
+        assertEquals(study.getEndDate(), studyCreateRequest.endDate());
+    }
+
+    @Test
+    @DisplayName("정상적으로 스터디를 삭제할 수 있다.")
+    void 정상적으로_스터디를_삭제할_수_있다() throws Exception {
+        Study study = algorithm_study();
+        studyRepository.save(study);
+        studyService.deleteStudy(study.getId());
+        List<Study> studies = studyRepository.findAll();
+        assertThat(studies).hasSize(0);
+    }
+
+    @Nested
+    @DisplayName("스터디 조회 테스트")
+    class StudyGetTest {
+        @Test
+        @DisplayName("정상적으로 스터디를 조회할 수 있다.")
+        void 정상적으로_스터디를_조회할_수_있다_성공() throws Exception {
+            Study study = algorithm_study();
+            studyRepository.save(study);
+            assertEquals(study.getId(), studyService.findStudyById(study.getId()).getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 스터디를 조회할 수 없다.")
+        void 존재하지_않는_스터디를_조회할_수_없다_실패() throws Exception {
+            Long notExistingStudyId = 0L;
+            assertThatThrownBy(() -> studyService.findStudyById(notExistingStudyId))
+                    .isInstanceOf(StudyException.class)
+                    .hasMessage(NOT_FOUND_STUDY.errorMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("스터디 종료 테스트")
+    class StudyTerminatetest {
+        @Test
+        @DisplayName("정상적으로 스터디를 종료할 수 있다.")
+        void 정상적으로_스터디를_종료할_수_있다_성공() throws Exception {
+            final Study study = algorithm_study();
+            studyRepository.save(study);
+            studyService.terminateStudy(study.getId());
+
+            assertEquals(ENDED, study.getStatus());
+        }
+
+        @Test
+        @DisplayName("종료된 스터디를 종료할 수 없다.")
+        void 종료된_스터디를_종료할_수_없다_실패() throws Exception {
+            final Study study = algorithm_study();
+            study.setStatus(ENDED);
+            studyRepository.save(study);
+
+            assertThatThrownBy(() -> studyService.terminateStudy(study.getId()))
+                    .isInstanceOf(StudyException.class)
+                    .hasMessage(TERMINATED_STUDY.errorMessage());
+
+        }
+    }
+
+    @Nested
+    @DisplayName("스터디 수정 테스트")
+    class StudyupdateTest {
+        final StudyUpdateRequest request = studyUpdateRequest();
+
+        @Test
+        @DisplayName("정상적으로_스터디를_수정할_수_있다.")
+        void 정상적으로_스터디를_수정할_수_있다_성공() throws Exception {
+            final Study study = algorithm_study();
+            studyRepository.save(study);
+            studyService.updateStudy(request, study.getId());
+            assertEquals(study.getName(), request.name());
+        }
+
+        @Test
+        @DisplayName("존재하지_않는_스터디를_수정할_수_없다.")
+        void 존재하지_않는_스터디를_수정할_수_없다_실패() throws Exception {
+            Long notExistingStudyId = 0L;
+            assertThatThrownBy(() -> studyService.updateStudy(request, notExistingStudyId))
+                    .isInstanceOf(StudyException.class)
+                    .hasMessage(NOT_FOUND_STUDY.errorMessage());
+        }
+    }
+}

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -6,6 +6,7 @@ import static doore.study.StudyFixture.studyUpdateRequest;
 import static doore.study.domain.StudyStatus.ENDED;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 import static doore.study.exception.StudyExceptionType.TERMINATED_STUDY;
+import static doore.team.TeamFixture.team;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,24 +17,31 @@ import doore.study.application.dto.request.StudyUpdateRequest;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
+import doore.team.domain.Team;
+import doore.team.domain.TeamRepository;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 public class StudyServiceTest extends IntegrationTest {
     @Autowired
     StudyService studyService;
     @Autowired
     StudyRepository studyRepository;
+    @Autowired
+    TeamRepository teamRepository;
 
     @Test
     @DisplayName("정상적으로 스터디를 생성할 수 있다.")
     void 정상적으로_스터디를_생성할_수_있다_성공() throws Exception {
         StudyCreateRequest studyCreateRequest = studyCreateRequest();
-        studyService.createStudy(studyCreateRequest, 1L);
-
+        Team team = team();
+        teamRepository.save(team);
+        studyService.createStudy(studyCreateRequest, team.getId());
         List<Study> studies = studyRepository.findAll();
         assertThat(studies).hasSize(1);
         Study study = studies.get(0);

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -1,7 +1,6 @@
 package doore.study.application;
 
 import static doore.study.StudyFixture.algorithm_study;
-import static doore.study.StudyFixture.studyCreateRequest;
 import static doore.study.StudyFixture.studyUpdateRequest;
 import static doore.study.domain.StudyStatus.ENDED;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
@@ -21,6 +20,8 @@ import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
 import doore.team.domain.Team;
 import doore.team.domain.TeamRepository;
+import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,7 +47,14 @@ public class StudyServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            studyCreateRequest = studyCreateRequest();
+            studyCreateRequest = StudyCreateRequest.builder()
+                    .name("자바 스터디")
+                    .description("자바 스터디 입니다")
+                    .startDate(LocalDate.parse("2020-02-02"))
+                    .endDate(null)
+                    .cropId(1L)
+                    .curriculumItems(null)
+                    .build();
             team = team();
             teamRepository.save(team);
         }
@@ -75,6 +83,15 @@ public class StudyServiceTest extends IntegrationTest {
                     () -> assertEquals(false, study.getIsDeleted())
             );
 
+        }
+
+        @Test
+        @DisplayName("스터디 생성시 curriculum을 작성하지 않으면 빈 리스트로 생성된다.")
+        void 스터디_생성시_curriculum을_작성하지_않으면_빈_리스트로_생성된다_성공() throws Exception {
+            studyCommandService.createStudy(studyCreateRequest, team.getId());
+            List<Study> studies = studyRepository.findAll();
+            Study study = studies.get(0);
+            assertEquals(Collections.emptyList(),study.getCurriculumItems());
         }
 
     }

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -9,7 +9,9 @@ import static doore.study.exception.StudyExceptionType.TERMINATED_STUDY;
 import static doore.team.TeamFixture.team;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static doore.study.domain.StudyStatus.UPCOMING;
 
 import doore.helper.IntegrationTest;
 import doore.study.application.dto.request.StudyCreateRequest;
@@ -20,6 +22,7 @@ import doore.study.exception.StudyException;
 import doore.team.domain.Team;
 import doore.team.domain.TeamRepository;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,20 +38,45 @@ public class StudyServiceTest extends IntegrationTest {
     @Autowired
     TeamRepository teamRepository;
 
-    @Test
-    @DisplayName("정상적으로 스터디를 생성할 수 있다.")
-    void 정상적으로_스터디를_생성할_수_있다_성공() throws Exception {
-        StudyCreateRequest studyCreateRequest = studyCreateRequest();
-        Team team = team();
-        teamRepository.save(team);
-        studyCommandService.createStudy(studyCreateRequest, team.getId());
-        List<Study> studies = studyRepository.findAll();
-        assertThat(studies).hasSize(1);
-        Study study = studies.get(0);
-        assertEquals(study.getName(), studyCreateRequest.name());
-        assertEquals(study.getDescription(), studyCreateRequest.description());
-        assertEquals(study.getStartDate(), studyCreateRequest.startDate());
-        assertEquals(study.getEndDate(), studyCreateRequest.endDate());
+    @Nested
+    @DisplayName("스터디 생성 테스트")
+    class StudyCreateTest {
+        StudyCreateRequest studyCreateRequest;
+        Team team;
+
+        @BeforeEach
+        void setUp() {
+            studyCreateRequest = studyCreateRequest();
+            team = team();
+            teamRepository.save(team);
+        }
+
+        @Test
+        @DisplayName("정상적으로 스터디를 생성할 수 있다.")
+        void 정상적으로_스터디를_생성할_수_있다_성공() throws Exception {
+            studyCommandService.createStudy(studyCreateRequest, team.getId());
+            List<Study> studies = studyRepository.findAll();
+            assertThat(studies).hasSize(1);
+            Study study = studies.get(0);
+            assertEquals(study.getName(), studyCreateRequest.name());
+            assertEquals(study.getDescription(), studyCreateRequest.description());
+            assertEquals(study.getStartDate(), studyCreateRequest.startDate());
+            assertEquals(study.getEndDate(), studyCreateRequest.endDate());
+        }
+
+        @Test
+        @DisplayName("스터디의 status와 isDeleted가 초기값으로 초기화 된다.")
+        void 스터디의_status와_isDeleted가_초기값으로_초기화_된다_성공() throws Exception {
+            studyCommandService.createStudy(studyCreateRequest, team.getId());
+            List<Study> studies = studyRepository.findAll();
+            Study study = studies.get(0);
+            assertAll(
+                    () -> assertEquals(UPCOMING, study.getStatus()),
+                    () -> assertEquals(false, study.getIsDeleted())
+            );
+
+        }
+
     }
 
     @Test

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -27,7 +27,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class StudyServiceTest extends IntegrationTest {
     @Autowired
-    StudyService studyService;
+    StudyCommandService studyCommandService;
+    @Autowired
+    StudyQueryService studyQueryService;
     @Autowired
     StudyRepository studyRepository;
     @Autowired
@@ -39,7 +41,7 @@ public class StudyServiceTest extends IntegrationTest {
         StudyCreateRequest studyCreateRequest = studyCreateRequest();
         Team team = team();
         teamRepository.save(team);
-        studyService.createStudy(studyCreateRequest, team.getId());
+        studyCommandService.createStudy(studyCreateRequest, team.getId());
         List<Study> studies = studyRepository.findAll();
         assertThat(studies).hasSize(1);
         Study study = studies.get(0);
@@ -54,7 +56,7 @@ public class StudyServiceTest extends IntegrationTest {
     void 정상적으로_스터디를_삭제할_수_있다() throws Exception {
         Study study = algorithm_study();
         studyRepository.save(study);
-        studyService.deleteStudy(study.getId());
+        studyCommandService.deleteStudy(study.getId());
         List<Study> studies = studyRepository.findAll();
         assertThat(studies).hasSize(0);
     }
@@ -67,14 +69,14 @@ public class StudyServiceTest extends IntegrationTest {
         void 정상적으로_스터디를_조회할_수_있다_성공() throws Exception {
             Study study = algorithm_study();
             studyRepository.save(study);
-            assertEquals(study.getId(), studyService.findStudyById(study.getId()).id());
+            assertEquals(study.getId(), studyQueryService.findStudyById(study.getId()).id());
         }
 
         @Test
         @DisplayName("존재하지 않는 스터디를 조회할 수 없다.")
         void 존재하지_않는_스터디를_조회할_수_없다_실패() throws Exception {
             Long notExistingStudyId = 0L;
-            assertThatThrownBy(() -> studyService.findStudyById(notExistingStudyId))
+            assertThatThrownBy(() -> studyQueryService.findStudyById(notExistingStudyId))
                     .isInstanceOf(StudyException.class)
                     .hasMessage(NOT_FOUND_STUDY.errorMessage());
         }
@@ -88,7 +90,7 @@ public class StudyServiceTest extends IntegrationTest {
         void 정상적으로_스터디를_종료할_수_있다_성공() throws Exception {
             final Study study = algorithm_study();
             studyRepository.save(study);
-            studyService.terminateStudy(study.getId());
+            studyCommandService.terminateStudy(study.getId());
 
             assertEquals(ENDED, study.getStatus());
         }
@@ -100,7 +102,7 @@ public class StudyServiceTest extends IntegrationTest {
             study.setStatus(ENDED);
             studyRepository.save(study);
 
-            assertThatThrownBy(() -> studyService.terminateStudy(study.getId()))
+            assertThatThrownBy(() -> studyCommandService.terminateStudy(study.getId()))
                     .isInstanceOf(StudyException.class)
                     .hasMessage(TERMINATED_STUDY.errorMessage());
 
@@ -117,7 +119,7 @@ public class StudyServiceTest extends IntegrationTest {
         void 정상적으로_스터디를_수정할_수_있다_성공() throws Exception {
             final Study study = algorithm_study();
             studyRepository.save(study);
-            studyService.updateStudy(request, study.getId());
+            studyCommandService.updateStudy(request, study.getId());
             assertEquals(study.getName(), request.name());
         }
 
@@ -125,7 +127,7 @@ public class StudyServiceTest extends IntegrationTest {
         @DisplayName("존재하지_않는_스터디를_수정할_수_없다.")
         void 존재하지_않는_스터디를_수정할_수_없다_실패() throws Exception {
             Long notExistingStudyId = 0L;
-            assertThatThrownBy(() -> studyService.updateStudy(request, notExistingStudyId))
+            assertThatThrownBy(() -> studyCommandService.updateStudy(request, notExistingStudyId))
                     .isInstanceOf(StudyException.class)
                     .hasMessage(NOT_FOUND_STUDY.errorMessage());
         }

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 public class StudyServiceTest extends IntegrationTest {
     @Autowired
     StudyService studyService;

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -3,6 +3,7 @@ package doore.study.application;
 import static doore.study.StudyFixture.algorithm_study;
 import static doore.study.StudyFixture.studyUpdateRequest;
 import static doore.study.domain.StudyStatus.ENDED;
+import static doore.study.exception.StudyExceptionType.NOT_FOUND_STATUS;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 import static doore.study.exception.StudyExceptionType.ALREADY_TERMINATED_STUDY;
 import static doore.team.TeamFixture.team;
@@ -175,6 +176,20 @@ public class StudyServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> studyCommandService.updateStudy(request, notExistingStudyId))
                     .isInstanceOf(StudyException.class)
                     .hasMessage(NOT_FOUND_STUDY.errorMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("스터디 상태 수정 테스트")
+    class StudyChangeStatusTest {
+        @Test
+        @DisplayName("존재하지 않는 상태로 변경할 수 없다.")
+        void 존재하지_않는_상태로_변경할_수_없다_실패() throws Exception {
+            final Study study = algorithm_study();
+            studyRepository.save(study);
+            assertThatThrownBy(() -> studyCommandService.changeStudyStatus("NOT_EXISTING_STATUS",study.getId()))
+                    .isInstanceOf(StudyException.class)
+                    .hasMessage(NOT_FOUND_STATUS.errorMessage());
         }
     }
 }

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -1,7 +1,6 @@
 package doore.study.application;
 
-import static doore.study.StudyFixture.algorithm_study;
-import static doore.study.StudyFixture.studyUpdateRequest;
+import static doore.study.StudyFixture.algorithmStudy;
 import static doore.study.domain.StudyStatus.ENDED;
 import static doore.study.exception.StudyExceptionType.*;
 import static doore.team.TeamFixture.team;
@@ -15,6 +14,7 @@ import doore.helper.IntegrationTest;
 import doore.study.application.dto.request.StudyCreateRequest;
 import doore.study.application.dto.request.StudyUpdateRequest;
 import doore.study.domain.Study;
+import doore.study.domain.StudyStatus;
 import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
 import doore.team.domain.Team;
@@ -113,7 +113,7 @@ public class StudyServiceTest extends IntegrationTest {
     @Test
     @DisplayName("정상적으로 스터디를 삭제할 수 있다.")
     void 정상적으로_스터디를_삭제할_수_있다() throws Exception {
-        Study study = algorithm_study();
+        Study study = algorithmStudy();
         studyRepository.save(study);
         studyCommandService.deleteStudy(study.getId());
         List<Study> studies = studyRepository.findAll();
@@ -126,7 +126,7 @@ public class StudyServiceTest extends IntegrationTest {
         @Test
         @DisplayName("정상적으로 스터디를 조회할 수 있다.")
         void 정상적으로_스터디를_조회할_수_있다_성공() throws Exception {
-            Study study = algorithm_study();
+            Study study = algorithmStudy();
             studyRepository.save(study);
             assertEquals(study.getId(), studyQueryService.findStudyById(study.getId()).id());
         }
@@ -147,7 +147,7 @@ public class StudyServiceTest extends IntegrationTest {
         @Test
         @DisplayName("정상적으로 스터디를 종료할 수 있다.")
         void 정상적으로_스터디를_종료할_수_있다_성공() throws Exception {
-            final Study study = algorithm_study();
+            final Study study = algorithmStudy();
             studyRepository.save(study);
             studyCommandService.terminateStudy(study.getId());
 
@@ -158,12 +158,18 @@ public class StudyServiceTest extends IntegrationTest {
     @Nested
     @DisplayName("스터디 수정 테스트")
     class StudyupdateTest {
-        final StudyUpdateRequest request = studyUpdateRequest();
+        final StudyUpdateRequest request = StudyUpdateRequest.builder()
+                .name("스프링")
+                .description("스프링 스터디 입니다.")
+                .startDate(LocalDate.parse("2023-01-01"))
+                .endDate(LocalDate.parse("2024-01-01"))
+                .status(StudyStatus.IN_PROGRESS)
+                .build();
 
         @Test
         @DisplayName("정상적으로_스터디를_수정할_수_있다.")
         void 정상적으로_스터디를_수정할_수_있다_성공() throws Exception {
-            final Study study = algorithm_study();
+            final Study study = algorithmStudy();
             studyRepository.save(study);
             studyCommandService.updateStudy(request, study.getId());
             assertEquals(study.getName(), request.name());
@@ -185,7 +191,7 @@ public class StudyServiceTest extends IntegrationTest {
         @Test
         @DisplayName("존재하지 않는 상태로 변경할 수 없다.")
         void 존재하지_않는_상태로_변경할_수_없다_실패() throws Exception {
-            final Study study = algorithm_study();
+            final Study study = algorithmStudy();
             studyRepository.save(study);
             assertThatThrownBy(() -> studyCommandService.changeStudyStatus("NOT_EXISTING_STATUS", study.getId()))
                     .isInstanceOf(StudyException.class)

--- a/src/test/java/doore/study/application/StudyServiceTest.java
+++ b/src/test/java/doore/study/application/StudyServiceTest.java
@@ -153,19 +153,6 @@ public class StudyServiceTest extends IntegrationTest {
 
             assertEquals(ENDED, study.getStatus());
         }
-
-        @Test
-        @DisplayName("종료된 스터디를 종료할 수 없다.")
-        void 종료된_스터디를_종료할_수_없다_실패() throws Exception {
-            final Study study = algorithm_study();
-            study.setStatus(ENDED);
-            studyRepository.save(study);
-
-            assertThatThrownBy(() -> studyCommandService.terminateStudy(study.getId()))
-                    .isInstanceOf(StudyException.class)
-                    .hasMessage(ALREADY_TERMINATED_STUDY.errorMessage());
-
-        }
     }
 
     @Nested

--- a/src/test/java/doore/study/domain/StudyTest.java
+++ b/src/test/java/doore/study/domain/StudyTest.java
@@ -15,19 +15,19 @@ public class StudyTest {
     @DisplayName("커리큘럼을 생성할 수 있다.")
     public void 커리큘럼을_생성할_수_있다_성공() {
         final Study study = algorithmStudy();
-        CurriculumItem curriculumItem1 = CurriculumItem.builder()
+        CurriculumItem curriculumItem = CurriculumItem.builder()
                 .name("커리큘럼 1단계")
                 .itemOrder(1)
                 .isDeleted(false)
                 .study(study)
                 .build();
-        CurriculumItem curriculumItem2 = CurriculumItem.builder()
+        CurriculumItem otherCurriculumItem = CurriculumItem.builder()
                 .name("커리큘럼 2단계")
                 .itemOrder(2)
                 .isDeleted(false)
                 .study(study)
                 .build();
-        List<CurriculumItem> curriculumItems = List.of(curriculumItem1, curriculumItem2);
+        List<CurriculumItem> curriculumItems = List.of(curriculumItem, otherCurriculumItem);
 
         study.createCurriculumItems(curriculumItems);
         assertEquals(curriculumItems, study.getCurriculumItems());

--- a/src/test/java/doore/study/domain/StudyTest.java
+++ b/src/test/java/doore/study/domain/StudyTest.java
@@ -1,0 +1,46 @@
+package doore.study.domain;
+
+import static doore.study.StudyFixture.algorithm_study;
+import static doore.study.StudyFixture.studyUpdateRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import doore.study.application.dto.request.StudyUpdateRequest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class StudyTest {
+
+    @Test
+    @DisplayName("커리큘럼을 생성할 수 있다.")
+    public void 커리큘럼을_생성할_수_있다_성공() {
+        final Study study = algorithm_study();
+        CurriculumItem curriculumItem1 = CurriculumItem.builder()
+                .name("커리큘럼 1단계")
+                .itemOrder(1)
+                .isDeleted(false)
+                .study(study)
+                .build();
+        CurriculumItem curriculumItem2 = CurriculumItem.builder()
+                .name("커리큘럼 2단계")
+                .itemOrder(2)
+                .isDeleted(false)
+                .study(study)
+                .build();
+        List<CurriculumItem> curriculumItems = List.of(curriculumItem1, curriculumItem2);
+
+        study.createCurriculumItems(curriculumItems);
+        assertEquals(curriculumItems, study.getCurriculumItems());
+    }
+
+    @Test
+    @DisplayName("스터디의 내용을 변경할 수 있다.")
+    public void 스터디의_내용을_변경할_수_있다_성공() {
+        final Study study = algorithm_study();
+        StudyUpdateRequest request = studyUpdateRequest();
+        study.update(request);
+        assertEquals(study.getName(), request.name());
+        assertEquals(study.getDescription(), request.description());
+    }
+
+}

--- a/src/test/java/doore/study/domain/StudyTest.java
+++ b/src/test/java/doore/study/domain/StudyTest.java
@@ -1,10 +1,10 @@
 package doore.study.domain;
 
-import static doore.study.StudyFixture.algorithm_study;
-import static doore.study.StudyFixture.studyUpdateRequest;
+import static doore.study.StudyFixture.algorithmStudy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import doore.study.application.dto.request.StudyUpdateRequest;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,7 +14,7 @@ public class StudyTest {
     @Test
     @DisplayName("커리큘럼을 생성할 수 있다.")
     public void 커리큘럼을_생성할_수_있다_성공() {
-        final Study study = algorithm_study();
+        final Study study = algorithmStudy();
         CurriculumItem curriculumItem1 = CurriculumItem.builder()
                 .name("커리큘럼 1단계")
                 .itemOrder(1)
@@ -36,8 +36,14 @@ public class StudyTest {
     @Test
     @DisplayName("스터디의 내용을 변경할 수 있다.")
     public void 스터디의_내용을_변경할_수_있다_성공() {
-        final Study study = algorithm_study();
-        StudyUpdateRequest request = studyUpdateRequest();
+        final Study study = algorithmStudy();
+        StudyUpdateRequest request = StudyUpdateRequest.builder()
+                .name("스프링")
+                .description("스프링 스터디 입니다.")
+                .startDate(LocalDate.parse("2023-01-01"))
+                .endDate(LocalDate.parse("2024-01-01"))
+                .status(StudyStatus.IN_PROGRESS)
+                .build();
         study.update(request.name(), request.description(), request.startDate(), request.endDate(), request.status());
         assertEquals(study.getName(), request.name());
         assertEquals(study.getDescription(), request.description());

--- a/src/test/java/doore/study/domain/StudyTest.java
+++ b/src/test/java/doore/study/domain/StudyTest.java
@@ -38,7 +38,7 @@ public class StudyTest {
     public void 스터디의_내용을_변경할_수_있다_성공() {
         final Study study = algorithm_study();
         StudyUpdateRequest request = studyUpdateRequest();
-        study.update(request);
+        study.update(request.name(), request.description(), request.startDate(), request.endDate(), request.status());
         assertEquals(study.getName(), request.name());
         assertEquals(study.getDescription(), request.description());
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #14

## 📝 작업 내용

스터디 CRUD를 작업했습니다. 
원래 스터디장 위임도 제가 하기로 했었는데 저희가 study에 leader_Id를 빼버리고 Role 테이블을 아직 안만들어서 아직 못했습니다
밥먹고 와서 코드 한 번 더 보면서 수정할 부분 있으면 수정하겠습니다~!

## 💬 리뷰 요구사항(선택)
- 스터디 조회 테스트) 만들어진 api 문서의 스터디 조회에 responseBody가 안뜨는데 이유를 모르겠습니다...ㅡㅡ;;
- 스터디 수정) 수정해도 될 부분은 이름,설명,시작 날짜, 종료 날짜, 상태 정도로 보여서 수정 dto에 해당 필드만 만들어뒀습니다. 그런데 사용자가 위 필드 중 일부만 수정했을 경우 이전 데이터에서 변경되지 않은 부분의 데이터를 들고오는 작업은 프론트에서 해야하는 건가요 백엔드에서 해야하는 건가요...? 백엔드에서 하려니 dto 필드값에 @NotNull 어노테이션을 지워야 할 거 같아 일단 그대로 뒀습니다.


## ⏰ 예상했던 소요시간/실제 소요시간(선택)

예상했던 것보다 정확히 세배 걸린듯요..하하 