### PR TITLE
Feature/#37-rest_docs_배포_문제_해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,37 +28,41 @@ ext {
     snippetsDir = file('build/generated-snippets')
 }
 
-test {
-    useJUnitPlatform()
-    outputs.dir snippetsDir
-}
-
-asciidoctor {
-    doFirst {
-        project.delete(files("src/main/resources/static/docs"))
+tasks {
+    test {
+        useJUnitPlatform()
+        outputs.dir snippetsDir
     }
-    inputs.dir snippetsDir
-    configurations 'asciidoctorExt'
-    dependsOn test
-    baseDirFollowsSourceFile()
-}
 
-tasks.register('copyDocument', Copy) {
-    dependsOn asciidoctor
-    from file("${asciidoctor.outputDir}")
-    into file("src/main/resources/static/docs")
-}
+    asciidoctor {
+        doFirst {
+            project.delete(files("src/main/resources/static/docs"))
+        }
+        inputs.dir snippetsDir
+        configurations 'asciidoctorExt'
+        dependsOn test
+        baseDirFollowsSourceFile()
+    }
 
-bootJar {
-    dependsOn asciidoctor
-    from("${asciidoctor.outputDir}/html5") {
-        into "static/docs"
+    tasks.register('copyDocument', Copy) {
+        dependsOn asciidoctor
+        from file("${asciidoctor.outputDir}")
+        into file("src/main/resources/static/docs")
+    }
+
+    bootJar {
+        dependsOn asciidoctor
+        from("${asciidoctor.outputDir}") {
+            into "static/docs"
+        }
+    }
+
+    build {
+        dependsOn copyDocument
     }
 }
 
-build {
-    dependsOn copyDocument
-}
+
 /******* End Spring Rest Docs *******/
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ tasks {
     }
 }
 
-
 /******* End Spring Rest Docs *******/
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ tasks {
 
     bootJar {
         dependsOn asciidoctor
-        from("${asciidoctor.outputDir}/html5") {
+        from("${asciidoctor.outputDir}") {
             into "static/docs"
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ tasks {
 
     bootJar {
         dependsOn asciidoctor
-        from("${asciidoctor.outputDir}") {
+        from("${asciidoctor.outputDir}/html5") {
             into "static/docs"
         }
     }

--- a/src/docs/asciidoc/doore.adoc
+++ b/src/docs/asciidoc/doore.adoc
@@ -10,17 +10,11 @@ endif::[]
 :toclevels: 2
 :seclinks:
 
-== *TEAM*
-
-=== `POST`: Team 생성
-
-.HTTP Request
-include::{snippets}/team-create/http-request.adoc[]
-
-.Request Fields
-include::{snippets}/team-create/request-fields.adoc[]
-
-.HTTP Response
-include::{snippets}/team-create/http-response.adoc[]
 
 link:./login.html[Login API]
+
+link:./curriculumItem.html[CurriculumItem API]
+
+link:./study.html[Study API]
+
+link:./team.html[Team API]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

https://github.com/BDD-CLUB/01-doo-re-back/issues/37

## 📝 작업 내용

과거 KEEPER PR을 뒤져보다가 /html5 경로를 삭제한 것을 확인해서 변경했습니다.

직접 배포해야 버그가 고쳐진 것인지 확인할 수 있어서 PR을 올립니다~!

+) 해결했습니다. 이제 빌드 한번만으로도 잘 배포됩니다~~

## ⏰ 예상했던 소요시간/실제 소요시간(선택)

3Day / 9Day
