### PR TITLE
Feature/#63 팀원 목록 조회 및 검색 구현

### DIFF
--- a/src/docs/asciidoc/doore.adoc
+++ b/src/docs/asciidoc/doore.adoc
@@ -10,7 +10,6 @@ endif::[]
 :toclevels: 2
 :seclinks:
 
-
 link:./login.html[Login API]
 
 link:./curriculumItem.html[CurriculumItem API]
@@ -18,3 +17,5 @@ link:./curriculumItem.html[CurriculumItem API]
 link:./study.html[Study API]
 
 link:./team.html[Team API]
+
+link:./memberTeam.html[팀원 API]

--- a/src/docs/asciidoc/memberTeam.adoc
+++ b/src/docs/asciidoc/memberTeam.adoc
@@ -1,0 +1,28 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= MEMBER_TEAM API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+== API 목록
+
+link:../doore.html[API 목록으로 돌아가기]
+
+== `GET`: 팀원 목록 조회
+.HTTP Request
+include::{snippets}/member-team-find/http-request.adoc[]
+
+.Query Parameters
+include::{snippets}/member-team-find/query-parameters.adoc[]
+
+.HTTP Response
+include::{snippets}/member-team-find/http-response.adoc[]
+
+.Response Body
+include::{snippets}/member-team-find/response-fields.adoc[]

--- a/src/main/java/doore/member/api/MemberTeamController.java
+++ b/src/main/java/doore/member/api/MemberTeamController.java
@@ -1,0 +1,26 @@
+package doore.member.api;
+
+import doore.member.application.MemberTeamQueryService;
+import doore.member.application.dto.response.MemberResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+public class MemberTeamController {
+    private final MemberTeamQueryService memberTeamQueryService;
+
+    @GetMapping("/teams/{teamId}/members")
+    public ResponseEntity<List<MemberResponse>> getMemberTeam(@PathVariable Long teamId,
+                                                              @RequestParam(value = "keyword", required = false) final String keyword) {
+        final List<MemberResponse> memberResponses = memberTeamQueryService.findMemberTeams(teamId, keyword);
+        return ResponseEntity.ok(memberResponses);
+    }
+}

--- a/src/main/java/doore/member/api/MemberTeamController.java
+++ b/src/main/java/doore/member/api/MemberTeamController.java
@@ -18,7 +18,7 @@ public class MemberTeamController {
     private final MemberTeamQueryService memberTeamQueryService;
 
     @GetMapping("/teams/{teamId}/members")
-    public ResponseEntity<List<MemberResponse>> getMemberTeam(@PathVariable Long teamId,
+    public ResponseEntity<List<MemberResponse>> getMemberTeam(@PathVariable final Long teamId,
                                                               @RequestParam(value = "keyword", required = false) final String keyword) {
         final List<MemberResponse> memberResponses = memberTeamQueryService.findMemberTeams(teamId, keyword);
         return ResponseEntity.ok(memberResponses);

--- a/src/main/java/doore/member/application/MemberTeamQueryService.java
+++ b/src/main/java/doore/member/application/MemberTeamQueryService.java
@@ -28,7 +28,8 @@ public class MemberTeamQueryService {
         final List<Member> members = memberTeamRepository.findAllByTeamIdAndKeyword(teamId, keyword)
                 .stream()
                 .map(MemberTeam::getMember)
-                .sorted(Comparator.comparing(Member::getName).thenComparing(member -> member.getName().length()))
+                .sorted(Comparator.comparing(Member::getName))
+                .sorted(Comparator.comparing(member -> member.getName().length()))
                 .collect(Collectors.toList());
         // 추후 role 구현 후 수정 예정
         final Map<Member, String> roleOfMembers = new HashMap<>();

--- a/src/main/java/doore/member/application/MemberTeamQueryService.java
+++ b/src/main/java/doore/member/application/MemberTeamQueryService.java
@@ -21,7 +21,7 @@ public class MemberTeamQueryService {
     private final MemberTeamRepository memberTeamRepository;
 
     public List<MemberResponse> findMemberTeams(final Long teamId, final String keyword) {
-        if (keyword == null || keyword.isBlank()) {
+        if (keyword.isBlank()) {
             return findAllMemberOfTeam(teamId);
         }
 
@@ -30,7 +30,7 @@ public class MemberTeamQueryService {
                 .map(MemberTeam::getMember)
                 .sorted(Comparator.comparing(Member::getName))
                 .sorted(Comparator.comparing(member -> member.getName().length()))
-                .collect(Collectors.toList());
+                .toList();
         // 추후 role 구현 후 수정 예정
         final Map<Member, String> roleOfMembers = new HashMap<>();
         members.stream()

--- a/src/main/java/doore/member/application/MemberTeamQueryService.java
+++ b/src/main/java/doore/member/application/MemberTeamQueryService.java
@@ -1,0 +1,52 @@
+package doore.member.application;
+
+import doore.member.application.dto.response.MemberResponse;
+import doore.member.domain.Member;
+import doore.member.domain.MemberTeam;
+import doore.member.domain.repository.MemberTeamRepository;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberTeamQueryService {
+
+    private final MemberTeamRepository memberTeamRepository;
+
+    public List<MemberResponse> findMemberTeams(final Long teamId, final String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return findAllMemberOfTeam(teamId);
+        }
+
+        final List<Member> members = memberTeamRepository.findAllByTeamIdAndKeyword(teamId, keyword)
+                .stream()
+                .map(MemberTeam::getMember)
+                .sorted(Comparator.comparing(Member::getName).thenComparing(member -> member.getName().length()))
+                .collect(Collectors.toList());
+        // 추후 role 구현 후 수정 예정
+        final Map<Member, String> roleOfMembers = new HashMap<>();
+        members.stream()
+                .forEach(member -> roleOfMembers.put(member, "팀원"));
+        return MemberResponse.of(members, roleOfMembers);
+    }
+
+    private List<MemberResponse> findAllMemberOfTeam(final Long teamId) {
+        final List<Member> members = memberTeamRepository.findAllByTeamId(teamId)
+                .stream()
+                .map(MemberTeam::getMember)
+                .sorted(Comparator.comparing(Member::getName))
+                .collect(Collectors.toList());
+        // 추후 role 구현 후 수정 예정
+        final Map<Member, String> roleOfMembers = new HashMap<>();
+        members.stream()
+                .forEach(member -> roleOfMembers.put(member, "팀원"));
+        return MemberResponse.of(members, roleOfMembers);
+    }
+}

--- a/src/main/java/doore/member/application/dto/response/MemberResponse.java
+++ b/src/main/java/doore/member/application/dto/response/MemberResponse.java
@@ -1,0 +1,33 @@
+package doore.member.application.dto.response;
+
+import doore.member.domain.Member;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberResponse {
+
+    private final Long id;
+    private final String name;
+    private final String email;
+    private final String imageUrl;
+    private final String role;  // 권한 기능 구현 후 수정 예정
+    private final boolean isDeleted;
+
+    public static List<MemberResponse> of(final List<Member> members, Map<Member, String> roleOfMembers) {
+        return members.stream()
+                .map(member -> new MemberResponse(
+                        member.getId(),
+                        member.getName(),
+                        member.getEmail(),
+                        member.getImageUrl(),
+                        roleOfMembers.get(member),
+                        member.getIsDeleted()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/doore/member/application/dto/response/MemberResponse.java
+++ b/src/main/java/doore/member/application/dto/response/MemberResponse.java
@@ -4,19 +4,15 @@ import doore.member.domain.Member;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
-public class MemberResponse {
-
-    private final Long id;
-    private final String name;
-    private final String email;
-    private final String imageUrl;
-    private final String role;  // 권한 기능 구현 후 수정 예정
-    private final boolean isDeleted;
+public record MemberResponse(
+        Long id,
+        String name,
+        String email,
+        String imageUrl,
+        String role,  // 권한 기능 구현 후 수정 예정
+        Boolean isDeleted
+) {
 
     public static List<MemberResponse> of(final List<Member> members, Map<Member, String> roleOfMembers) {
         return members.stream()

--- a/src/main/java/doore/member/domain/MemberTeam.java
+++ b/src/main/java/doore/member/domain/MemberTeam.java
@@ -10,12 +10,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
+@SQLDelete(sql = "UPDATE member_team SET is_deleted = true where id = ?")
 public class MemberTeam extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,4 +35,12 @@ public class MemberTeam extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @Builder
+    private MemberTeam(final Long id, final Long teamId, final Member member, final Boolean isDeleted) {
+        this.id = id;
+        this.teamId = teamId;
+        this.member = member;
+        this.isDeleted = isDeleted;
+    }
 }

--- a/src/main/java/doore/member/domain/repository/MemberTeamRepository.java
+++ b/src/main/java/doore/member/domain/repository/MemberTeamRepository.java
@@ -10,6 +10,6 @@ public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
 
     @Query("select mt from MemberTeam mt "
             + "where mt.teamId = :teamId "
-            + "and (mt.member.name like  ':keyword%' or mt.member.email like ':keyword%')")
+            + "and (mt.member.name like  :keyword% or mt.member.email like :keyword%)")
     List<MemberTeam> findAllByTeamIdAndKeyword(final Long teamId, final String keyword);
 }

--- a/src/main/java/doore/member/domain/repository/MemberTeamRepository.java
+++ b/src/main/java/doore/member/domain/repository/MemberTeamRepository.java
@@ -10,6 +10,6 @@ public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
 
     @Query("select mt from MemberTeam mt "
             + "where mt.teamId = :teamId "
-            + "and (mt.member.name like  :keyword% or mt.member.email like :keyword%)")
+            + "and (mt.member.name like :keyword% or mt.member.email like :keyword%)")
     List<MemberTeam> findAllByTeamIdAndKeyword(final Long teamId, final String keyword);
 }

--- a/src/main/java/doore/member/domain/repository/MemberTeamRepository.java
+++ b/src/main/java/doore/member/domain/repository/MemberTeamRepository.java
@@ -1,0 +1,15 @@
+package doore.member.domain.repository;
+
+import doore.member.domain.MemberTeam;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
+    List<MemberTeam> findAllByTeamId(final Long teamId);
+
+    @Query("select mt from MemberTeam mt "
+            + "where mt.teamId = :teamId "
+            + "and (mt.member.name like  ':keyword%' or mt.member.email like ':keyword%')")
+    List<MemberTeam> findAllByTeamIdAndKeyword(final Long teamId, final String keyword);
+}

--- a/src/test/java/doore/login/application/LoginServiceTest.java
+++ b/src/test/java/doore/login/application/LoginServiceTest.java
@@ -1,6 +1,6 @@
 package doore.login.application;
 
-import static doore.member.MemberFixture.회원;
+import static doore.member.MemberFixture.아마란스;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
@@ -25,7 +25,7 @@ class LoginServiceTest extends IntegrationTest {
 
     @BeforeEach
     void init() {
-        member = memberRepository.save(회원());
+        member = memberRepository.save(아마란스());
     }
 
     @Test

--- a/src/test/java/doore/member/MemberFixture.java
+++ b/src/test/java/doore/member/MemberFixture.java
@@ -3,12 +3,73 @@ package doore.member;
 import doore.member.domain.Member;
 
 public class MemberFixture {
-    public static Member 회원() {
+    public static Member 아마란스() {
         return Member.builder()
                 .name("아마란스")
                 .googleId("1234")
                 .email("bbb@gmail.com")
                 .imageUrl("https://aaa")
+                .googleId("48729483")
+                .build();
+    }
+
+    public static Member 아마어마어마() {
+        return Member.builder()
+                .name("아마어마어마")
+                .googleId("1234")
+                .email("bcde@gmail.com")
+                .imageUrl("https://aaa")
+                .googleId("48729483")
+                .build();
+    }
+
+    public static Member 아마스() {
+        return Member.builder()
+                .name("아마스")
+                .googleId("1234")
+                .email("test4@gmail.com")
+                .imageUrl("https://aaa")
+                .googleId("48729483")
+                .build();
+    }
+
+    public static Member 보름() {
+        return Member.builder()
+                .name("보름")
+                .googleId("1234")
+                .email("bbb@gmail.com")
+                .imageUrl("https://aaa")
+                .googleId("48729483")
+                .build();
+    }
+
+    public static Member 짱구() {
+        return Member.builder()
+                .name("짱구")
+                .googleId("1234")
+                .email("testtest@gmail.com")
+                .imageUrl("https://aaa")
+                .googleId("48729483")
+                .build();
+    }
+
+    public static Member 비비아마() {
+        return Member.builder()
+                .name("비비아마")
+                .googleId("1234")
+                .email("test@gmail.com")
+                .imageUrl("https://aaa")
+                .googleId("48729483")
+                .build();
+    }
+
+    public static Member 아마() {
+        return Member.builder()
+                .name("아마")
+                .googleId("1234")
+                .email("test@gmail.com")
+                .imageUrl("https://aaa")
+                .googleId("48729483")
                 .build();
     }
 }

--- a/src/test/java/doore/member/api/MemberTeamControllerTest.java
+++ b/src/test/java/doore/member/api/MemberTeamControllerTest.java
@@ -1,0 +1,30 @@
+package doore.member.api;
+
+import static doore.member.MemberFixture.아마란스;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import doore.helper.IntegrationTest;
+import doore.member.domain.Member;
+import doore.member.domain.MemberTeam;
+import doore.member.domain.repository.MemberRepository;
+import doore.member.domain.repository.MemberTeamRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberTeamControllerTest extends IntegrationTest {
+    @Autowired
+    private MemberTeamRepository memberTeamRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("정상적으로 팀원 목록을 조회한다.")
+    void 정상적으로_팀원_목록을_조회한다_성공() throws Exception {
+        final Member 아마란스 = memberRepository.save(아마란스());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마란스).isDeleted(false).build());
+        String url = "/teams/1/members";
+        callGetApi(url).andExpect(status().isOk());
+    }
+
+}

--- a/src/test/java/doore/member/api/MemberTeamControllerTest.java
+++ b/src/test/java/doore/member/api/MemberTeamControllerTest.java
@@ -22,7 +22,13 @@ class MemberTeamControllerTest extends IntegrationTest {
     @DisplayName("정상적으로 팀원 목록을 조회한다.")
     void 정상적으로_팀원_목록을_조회한다_성공() throws Exception {
         final Member 아마란스 = memberRepository.save(아마란스());
-        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마란스).isDeleted(false).build());
+        memberTeamRepository.save(
+                MemberTeam.builder()
+                        .teamId(1L)
+                        .member(아마란스)
+                        .isDeleted(false)
+                        .build()
+        );
         String url = "/teams/1/members";
         callGetApi(url).andExpect(status().isOk());
     }

--- a/src/test/java/doore/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberCommandServiceTest.java
@@ -1,6 +1,6 @@
 package doore.member.application;
 
-import static doore.member.MemberFixture.회원;
+import static doore.member.MemberFixture.아마란스;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -23,7 +23,7 @@ class MemberCommandServiceTest extends IntegrationTest {
 
     @BeforeEach
     void init() {
-        member = memberRepository.save(회원());
+        member = memberRepository.save(아마란스());
     }
 
     @Test

--- a/src/test/java/doore/member/application/MemberTeamQueryServiceTest.java
+++ b/src/test/java/doore/member/application/MemberTeamQueryServiceTest.java
@@ -1,0 +1,92 @@
+package doore.member.application;
+
+import doore.helper.IntegrationTest;
+import doore.member.application.dto.response.MemberResponse;
+import doore.member.domain.Member;
+import doore.member.domain.MemberTeam;
+import doore.member.domain.repository.MemberRepository;
+import doore.member.domain.repository.MemberTeamRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberTeamQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private MemberTeamQueryService memberTeamQueryService;
+    @Autowired
+    private MemberTeamRepository memberTeamRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member 아마란스;
+    private Member 아마어마어마;
+    private Member 아마스;
+    private Member 보름;
+    private Member 짱구;
+    private Member 비비아마;
+    private Member 아마;
+
+    @BeforeEach
+    void setup() {
+        아마란스 = memberRepository.save(Member.builder().name("아마란스").email("").imageUrl("").googleId("").build());
+        아마어마어마 = memberRepository.save(Member.builder().name("아마어마어마").email("").imageUrl("").googleId("").build());
+        아마스 = memberRepository.save(Member.builder().name("아마스").email("").imageUrl("").googleId("").build());
+        보름 = memberRepository.save(Member.builder().name("보름").email("").imageUrl("").googleId("").build());
+        짱구 = memberRepository.save(Member.builder().name("짱구").email("").imageUrl("").googleId("").build());
+        비비아마 = memberRepository.save(Member.builder().name("비비아마").email("").imageUrl("").googleId("").build());
+        아마 = memberRepository.save(Member.builder().name("아마").email("").imageUrl("").googleId("").build());
+
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마란스).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마어마어마).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마스).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(보름).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(짱구).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(비비아마).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(2L).member(아마).isDeleted(false).build());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀원들을 조회한다.")
+    void findMemberTeams_팀원들을_조회한다_성공() {
+        //given
+        final List<Member> members = List.of(보름, 비비아마, 아마란스, 아마스, 아마어마어마, 짱구);
+        final Map<Member, String> roleOfMembers = new HashMap<>();  // TODO: 3/1/24 수정
+        members.stream()
+                .forEach(member -> roleOfMembers.put(member, "팀원"));
+        final List<MemberResponse> expend = MemberResponse.of(members, roleOfMembers);
+
+        //when
+        final List<MemberResponse> actual = memberTeamQueryService.findMemberTeams(1L, null);
+
+        //then
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expend);
+    }
+
+    @Test
+    @DisplayName("[성공] 키워드를 입력받으면 이름 또는 이메일의 앞부분이 키워드와 일치하는 팀원들을 조회한다.")
+    void findMemberTeams_키워드를_입력받으면_이름_또는_이메일의_앞부분이_키워드와_일치하는_팀원들을_조회한다_성공() {
+        //given
+        final List<Member> members = List.of(아마스, 아마란스, 아마어마어마);
+        final Map<Member, String> roleOfMembers = new HashMap<>(); // TODO: 3/1/24 수정
+        members.stream()
+                .forEach(member -> roleOfMembers.put(member, "팀원"));
+        final List<MemberResponse> expend = MemberResponse.of(members, roleOfMembers);
+
+        //when
+        final List<MemberResponse> actual = memberTeamQueryService.findMemberTeams(1L, "아마");
+
+        //then
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expend);
+    }
+
+}

--- a/src/test/java/doore/member/application/MemberTeamQueryServiceTest.java
+++ b/src/test/java/doore/member/application/MemberTeamQueryServiceTest.java
@@ -1,5 +1,13 @@
 package doore.member.application;
 
+import static doore.member.MemberFixture.보름;
+import static doore.member.MemberFixture.비비아마;
+import static doore.member.MemberFixture.아마;
+import static doore.member.MemberFixture.아마란스;
+import static doore.member.MemberFixture.아마스;
+import static doore.member.MemberFixture.아마어마어마;
+import static doore.member.MemberFixture.짱구;
+
 import doore.helper.IntegrationTest;
 import doore.member.application.dto.response.MemberResponse;
 import doore.member.domain.Member;
@@ -34,13 +42,13 @@ class MemberTeamQueryServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setup() {
-        아마란스 = memberRepository.save(Member.builder().name("아마란스").email("").imageUrl("").googleId("").build());
-        아마어마어마 = memberRepository.save(Member.builder().name("아마어마어마").email("").imageUrl("").googleId("").build());
-        아마스 = memberRepository.save(Member.builder().name("아마스").email("").imageUrl("").googleId("").build());
-        보름 = memberRepository.save(Member.builder().name("보름").email("").imageUrl("").googleId("").build());
-        짱구 = memberRepository.save(Member.builder().name("짱구").email("").imageUrl("").googleId("").build());
-        비비아마 = memberRepository.save(Member.builder().name("비비아마").email("").imageUrl("").googleId("").build());
-        아마 = memberRepository.save(Member.builder().name("아마").email("").imageUrl("").googleId("").build());
+        아마란스 = memberRepository.save(아마란스());
+        아마어마어마 = memberRepository.save(아마어마어마());
+        아마스 = memberRepository.save(아마스());
+        보름 = memberRepository.save(보름());
+        짱구 = memberRepository.save(짱구());
+        비비아마 = memberRepository.save(비비아마());
+        아마 = memberRepository.save(아마());
 
         memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마란스).isDeleted(false).build());
         memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마어마어마).isDeleted(false).build());
@@ -71,8 +79,8 @@ class MemberTeamQueryServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[성공] 키워드를 입력받으면 이름 또는 이메일의 앞부분이 키워드와 일치하는 팀원들을 조회한다.")
-    void findMemberTeams_키워드를_입력받으면_이름_또는_이메일의_앞부분이_키워드와_일치하는_팀원들을_조회한다_성공() {
+    @DisplayName("[성공] 키워드를 입력받으면 이름의 앞부분이 키워드와 일치하는 팀원들을 조회한다.")
+    void findMemberTeams_키워드를_입력받으면_이름의_앞부분이_키워드와_일치하는_팀원들을_조회한다_성공() {
         //given
         final List<Member> members = List.of(아마스, 아마란스, 아마어마어마);
         final Map<Member, String> roleOfMembers = new HashMap<>(); // TODO: 3/1/24 수정
@@ -82,6 +90,25 @@ class MemberTeamQueryServiceTest extends IntegrationTest {
 
         //when
         final List<MemberResponse> actual = memberTeamQueryService.findMemberTeams(1L, "아마");
+
+        //then
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expend);
+    }
+
+    @Test
+    @DisplayName("[성공] 키워드를 입력받으면 이메일의 앞부분이 키워드와 일치하는 팀원들을 조회한다.")
+    void findMemberTeams_키워드를_입력받으면_이메일의_앞부분이_키워드와_일치하는_팀원들을_조회한다_성공() {
+        //given
+        final List<Member> members = List.of(짱구, 아마스, 비비아마);
+        final Map<Member, String> roleOfMembers = new HashMap<>(); // TODO: 3/1/24 수정
+        members.stream()
+                .forEach(member -> roleOfMembers.put(member, "팀원"));
+        final List<MemberResponse> expend = MemberResponse.of(members, roleOfMembers);
+
+        //when
+        final List<MemberResponse> actual = memberTeamQueryService.findMemberTeams(1L, "test");
 
         //then
         Assertions.assertThat(actual)

--- a/src/test/java/doore/member/domain/repository/MemberTeamRepositoryTest.java
+++ b/src/test/java/doore/member/domain/repository/MemberTeamRepositoryTest.java
@@ -1,0 +1,64 @@
+package doore.member.domain.repository;
+
+import doore.helper.RepositorySliceTest;
+import doore.member.domain.Member;
+import doore.member.domain.MemberTeam;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberTeamRepositoryTest extends RepositorySliceTest {
+    @Autowired
+    private MemberTeamRepository memberTeamRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member 아마란스;
+    private Member 아마어마어마;
+    private Member 아마스;
+    private Member 보름;
+    private Member 짱구;
+    private Member 비비아마;
+    private Member 아마;
+
+    @BeforeEach
+    void setup() {
+        아마란스 = memberRepository.save(Member.builder().name("아마란스").email("").imageUrl("").googleId("").build());
+        아마어마어마 = memberRepository.save(Member.builder().name("아마어마어마").email("").imageUrl("").googleId("").build());
+        아마스 = memberRepository.save(Member.builder().name("아마스").email("").imageUrl("").googleId("").build());
+        보름 = memberRepository.save(Member.builder().name("보름").email("").imageUrl("").googleId("").build());
+        짱구 = memberRepository.save(Member.builder().name("짱구").email("").imageUrl("").googleId("").build());
+        비비아마 = memberRepository.save(Member.builder().name("비비아마").email("").imageUrl("").googleId("").build());
+        아마 = memberRepository.save(Member.builder().name("아마").email("").imageUrl("").googleId("").build());
+
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마란스).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마어마어마).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마스).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(보름).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(짱구).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(비비아마).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(2L).member(아마).isDeleted(false).build());
+    }
+
+    @Test
+    @DisplayName("[성공] 키워드를 입력받으면 이름 또는 이메일의 앞부분이 키워드와 일치하는 팀원들을 조회한다.")
+    void findAllByTeamIdAndKeyword_키워드를_입력받으면_이름_또는_이메일의_앞부분이_키워드와_일치하는_팀원들을_조회한다_성공() {
+        //given
+        final List<Member> expend = List.of(아마란스, 아마어마어마, 아마스);
+
+        //when
+        final List<Member> actual = memberTeamRepository.findAllByTeamIdAndKeyword(1L, "아마")
+                .stream()
+                .map(MemberTeam::getMember)
+                .collect(Collectors.toList());
+
+        //then
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expend);
+    }
+}

--- a/src/test/java/doore/member/domain/repository/MemberTeamRepositoryTest.java
+++ b/src/test/java/doore/member/domain/repository/MemberTeamRepositoryTest.java
@@ -1,5 +1,13 @@
 package doore.member.domain.repository;
 
+import static doore.member.MemberFixture.보름;
+import static doore.member.MemberFixture.비비아마;
+import static doore.member.MemberFixture.아마;
+import static doore.member.MemberFixture.아마란스;
+import static doore.member.MemberFixture.아마스;
+import static doore.member.MemberFixture.아마어마어마;
+import static doore.member.MemberFixture.짱구;
+
 import doore.helper.RepositorySliceTest;
 import doore.member.domain.Member;
 import doore.member.domain.MemberTeam;
@@ -27,13 +35,13 @@ class MemberTeamRepositoryTest extends RepositorySliceTest {
 
     @BeforeEach
     void setup() {
-        아마란스 = memberRepository.save(Member.builder().name("아마란스").email("").imageUrl("").googleId("").build());
-        아마어마어마 = memberRepository.save(Member.builder().name("아마어마어마").email("").imageUrl("").googleId("").build());
-        아마스 = memberRepository.save(Member.builder().name("아마스").email("").imageUrl("").googleId("").build());
-        보름 = memberRepository.save(Member.builder().name("보름").email("").imageUrl("").googleId("").build());
-        짱구 = memberRepository.save(Member.builder().name("짱구").email("").imageUrl("").googleId("").build());
-        비비아마 = memberRepository.save(Member.builder().name("비비아마").email("").imageUrl("").googleId("").build());
-        아마 = memberRepository.save(Member.builder().name("아마").email("").imageUrl("").googleId("").build());
+        아마란스 = memberRepository.save(아마란스());
+        아마어마어마 = memberRepository.save(아마어마어마());
+        아마스 = memberRepository.save(아마스());
+        보름 = memberRepository.save(보름());
+        짱구 = memberRepository.save(짱구());
+        비비아마 = memberRepository.save(비비아마());
+        아마 = memberRepository.save(아마());
 
         memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마란스).isDeleted(false).build());
         memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마어마어마).isDeleted(false).build());

--- a/src/test/java/doore/restdocs/RestDocsTest.java
+++ b/src/test/java/doore/restdocs/RestDocsTest.java
@@ -7,6 +7,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import doore.helper.ApiTestHelper;
 import doore.login.application.LoginService;
 import doore.member.application.MemberCommandService;
+import doore.member.application.MemberTeamQueryService;
 import doore.study.application.CurriculumItemCommandService;
 import doore.study.application.StudyCommandService;
 import doore.study.application.StudyQueryService;
@@ -34,6 +35,9 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockBean
     protected MemberCommandService memberCommandService;
+
+    @MockBean
+    protected MemberTeamQueryService memberTeamQueryService;
 
     @MockBean
     protected TeamCommandService teamCommandService;
@@ -70,6 +74,11 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     protected FieldDescriptor numberFieldWithPath(final String path, final String description) {
         return fieldWithPath(path).type(JsonFieldType.NUMBER)
+                .description(description);
+    }
+
+    protected FieldDescriptor booleanFieldWithPath(final String path, final String description) {
+        return fieldWithPath(path).type(JsonFieldType.BOOLEAN)
                 .description(description);
     }
 

--- a/src/test/java/doore/restdocs/docs/MemberTeamApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/MemberTeamApiDocsTest.java
@@ -1,0 +1,92 @@
+package doore.restdocs.docs;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import doore.member.api.MemberTeamController;
+import doore.member.application.dto.response.MemberResponse;
+import doore.restdocs.RestDocsTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.restdocs.request.QueryParametersSnippet;
+
+@WebMvcTest(MemberTeamController.class)
+public class MemberTeamApiDocsTest extends RestDocsTest {
+
+    @Test
+    @DisplayName("팀원 목록을 조회한다.")
+    public void 팀원_목록을_조회한다() throws Exception {
+        //given
+        final QueryParametersSnippet queryParameters = queryParameters(
+                parameterWithName("keyword").optional().description("검색 단어(option)")
+        );
+        final ResponseFieldsSnippet responseFields = PayloadDocumentation.responseFields(
+                numberFieldWithPath("[].id", "회원 id"),
+                stringFieldWithPath("[].name", "회원 이름"),
+                stringFieldWithPath("[].email", "회원 이메일"),
+                stringFieldWithPath("[].imageUrl", "회원 프로필 이미지 url"),
+                stringFieldWithPath("[].role", "회원의 직책(추후 수정 예정)"),
+                booleanFieldWithPath("[].isDeleted", "회원의 삭제(탈퇴) 여부")
+        );
+        final List<MemberResponse> response = List.of(
+                new MemberResponse(2L, "보름", "borum@naver.com", "https://borum.png", "팀원", false),
+                new MemberResponse(1L, "아마란스", "songsy404@naver.com", "https://amaran-th.png", "팀장", false),
+                new MemberResponse(4L, "아마스빈", "amasbin@naver.com", "https://borum.png", "팀원", false),
+                new MemberResponse(5L, "아마아마아마", "amaamaama@naver.com", "https://zzanggu.png", "팀원", false),
+                new MemberResponse(3L, "짱구", "zzanggu@naver.com", "https://zzanggu.png", "팀원", false)
+        );
+
+        // when
+        when(memberTeamQueryService.findMemberTeams(anyLong(), eq(null))).thenReturn(response);
+
+        // then
+        mockMvc.perform(get("/teams/1/members")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andDo(document("member-team-find", queryParameters, responseFields));
+    }
+
+    @Test
+    @DisplayName("팀원 목록을 검색해서 조회한다.")
+    public void 팀원_목록을_검색해서_조회한다() throws Exception {
+        //given
+        final QueryParametersSnippet queryParameters = queryParameters(
+                parameterWithName("keyword").optional().description("검색 단어(option)")
+        );
+        final ResponseFieldsSnippet responseFields = PayloadDocumentation.responseFields(
+                numberFieldWithPath("[].id", "회원 id"),
+                stringFieldWithPath("[].name", "회원 이름"),
+                stringFieldWithPath("[].email", "회원 이메일"),
+                stringFieldWithPath("[].imageUrl", "회원 프로필 이미지 url"),
+                stringFieldWithPath("[].role", "회원의 직책(추후 수정 예정)"),
+                booleanFieldWithPath("[].isDeleted", "회원의 삭제(탈퇴) 여부")
+        );
+        final List<MemberResponse> response = List.of(
+                new MemberResponse(1L, "아마란스", "songsy404@naver.com", "https://amaran-th.png", "팀장", false),
+                new MemberResponse(4L, "아마스빈", "amasbin@naver.com", "https://borum.png", "팀원", false),
+                new MemberResponse(5L, "아마아마아마", "amaamaama@naver.com", "https://zzanggu.png", "팀원", false)
+        );
+
+        // when
+        when(memberTeamQueryService.findMemberTeams(anyLong(), anyString())).thenReturn(response);
+
+        // then
+        mockMvc.perform(get("/teams/1/members")
+                        .param("keyword", "아마")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andDo(document("member-team-find-search", queryParameters, responseFields));
+    }
+}

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -1,19 +1,19 @@
 package doore.study.api;
 
-import static doore.member.MemberFixture.회원;
+import static doore.member.MemberFixture.아마란스;
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.team.TeamFixture.team;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import doore.study.application.dto.request.StudyCreateRequest;
+import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
 import doore.member.domain.repository.MemberRepository;
-import doore.study.domain.repository.StudyRepository;
-import doore.team.domain.TeamRepository;
+import doore.study.application.dto.request.StudyCreateRequest;
 import doore.study.domain.Study;
+import doore.study.domain.repository.StudyRepository;
 import doore.team.domain.Team;
-import doore.helper.IntegrationTest;
+import doore.team.domain.TeamRepository;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +35,7 @@ public class StudyControllerTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        member = 회원();
+        member = 아마란스();
         study = algorithmStudy();
         memberRepository.save(member);
         studyRepository.save(study);

--- a/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
+++ b/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
@@ -97,7 +97,7 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 커리큘럼의 상태 변경이 가능하다.")
     public void checkCurriculum_커리큘럼의_상태_변경이_가능하다() throws Exception {
-        Member member = MemberFixture.회원();
+        Member member = MemberFixture.아마란스();
         memberRepository.save(member);
 
         Participant participant = Participant.builder()

--- a/src/test/java/doore/study/application/StudyCommandServiceTest.java
+++ b/src/test/java/doore/study/application/StudyCommandServiceTest.java
@@ -1,6 +1,6 @@
 package doore.study.application;
 
-import static doore.member.MemberFixture.회원;
+import static doore.member.MemberFixture.아마란스;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.study.domain.StudyStatus.ENDED;
@@ -210,7 +210,7 @@ public class StudyCommandServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            member = 회원();
+            member = 아마란스();
             study = algorithmStudy();
             memberRepository.save(member);
             studyRepository.save(study);

--- a/src/test/java/doore/study/application/StudyQueryServiceTest.java
+++ b/src/test/java/doore/study/application/StudyQueryServiceTest.java
@@ -1,6 +1,6 @@
 package doore.study.application;
 
-import static doore.member.MemberFixture.회원;
+import static doore.member.MemberFixture.아마란스;
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,7 +16,6 @@ import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -61,7 +60,7 @@ public class StudyQueryServiceTest extends IntegrationTest {
         @DisplayName("[성공] 참여자를 정상적으로 조회할 수 있다.")
         void findAllParticipants_참여자를_정상적으로_조회할_수_있다_성공() {
             //given
-            Member member = 회원();
+            Member member = 아마란스();
             memberRepository.save(member);
             Study study = algorithmStudy();
             studyRepository.save(study);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close: #63 

## 📝 작업 내용

특정 팀의 팀원 목록을 조회하는 기능 구현(키워드 입력 시 이름/이메일이 해당 키워드로 시작하는 팀원만 조회)

## ⏰ 예상했던 소요시간/실제 소요시간(선택)
02.29 / 03.01(1일 over)