### PR TITLE
Feature/#111 커리큘럼 관련 프론트 요청사항 수정

### DIFF
--- a/src/docs/asciidoc/curriculumItem.adoc
+++ b/src/docs/asciidoc/curriculumItem.adoc
@@ -22,6 +22,12 @@ include::{snippets}/curriculum-manage/http-request.adoc[]
 .HTTP Response
 include::{snippets}/curriculum-manage/http-response.adoc[]
 
+.Path Parameters
+include::{snippets}/curriculum-manage/path-parameters.adoc[]
+
+.Request Fields
+include::{snippets}/curriculum-manage/request-fields.adoc[]
+
 == `PATCH`: CurriculumItem 상태 변경
 
 .HTTP Request
@@ -29,3 +35,6 @@ include::{snippets}/curriculum-check/http-request.adoc[]
 
 .HTTP Response
 include::{snippets}/curriculum-check/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/curriculum-check/path-parameters.adoc[]

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -1,5 +1,6 @@
 package doore.study.application;
 
+import static doore.study.exception.CurriculumItemExceptionType.CANNOT_CREATE_CURRICULUM_ITEM;
 import static doore.study.exception.CurriculumItemExceptionType.INVALID_ITEM_ORDER;
 import static doore.study.exception.CurriculumItemExceptionType.NOT_FOUND_CURRICULUM_ITEM;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_PARTICIPANT;
@@ -81,6 +82,9 @@ public class CurriculumItemCommandService {
     }
 
     private void createCurriculum(Long studyId, List<CurriculumItemManageDetailRequest> curriculumItems) {
+        if (curriculumItemRepository.findAll().size() >= 99) {
+            throw new CurriculumItemException(CANNOT_CREATE_CURRICULUM_ITEM);
+        }
         curriculumItems.stream()
                 .filter(curriculumItem -> !isExistsCurriculumItem(curriculumItem.id()))
                 .forEach(curriculumItem -> createCurriculumItemAndAssignToParticipants(studyId, curriculumItem));

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -7,6 +7,7 @@ import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 
 import doore.member.domain.Participant;
 import doore.member.domain.repository.ParticipantRepository;
+import doore.study.application.dto.request.CurriculumItemManageDetailRequest;
 import doore.study.application.dto.request.CurriculumItemManageRequest;
 import doore.study.domain.CurriculumItem;
 import doore.study.domain.ParticipantCurriculumItem;
@@ -35,13 +36,13 @@ public class CurriculumItemCommandService {
     private final ParticipantRepository participantRepository;
 
     public void manageCurriculum(CurriculumItemManageRequest request, Long studyId) {
-        List<CurriculumItem> curriculumItems = request.curriculumItems();
+        List<CurriculumItemManageDetailRequest> curriculumItems = request.curriculumItems();
         checkItemOrderDuplicate(curriculumItems);
         checkItemOrderRange(curriculumItems);
         createCurriculum(studyId, curriculumItems);
         updateCurriculum(curriculumItems);
 
-        List<CurriculumItem> deletedCurriculumItems = request.deletedCurriculumItems();
+        List<CurriculumItemManageDetailRequest> deletedCurriculumItems = request.deletedCurriculumItems();
         deleteCurriculum(deletedCurriculumItems);
         sortCurriculum();
     }
@@ -57,11 +58,11 @@ public class CurriculumItemCommandService {
         participantCurriculumItem.checkCompletion();
     }
 
-    private void checkItemOrderDuplicate(List<CurriculumItem> curriculumItems) {
+    private void checkItemOrderDuplicate(List<CurriculumItemManageDetailRequest> curriculumItems) {
         Set<Integer> uniqueItemOrders = new HashSet<>();
 
         curriculumItems.stream()
-                .map(CurriculumItem::getItemOrder)
+                .map(CurriculumItemManageDetailRequest::itemOrder)
                 .forEach(itemOrder -> {
                     if (!uniqueItemOrders.add(itemOrder)) {
                         throw new CurriculumItemException(INVALID_ITEM_ORDER);
@@ -69,9 +70,9 @@ public class CurriculumItemCommandService {
                 });
     }
 
-    private void checkItemOrderRange(List<CurriculumItem> curriculumItems) {
+    private void checkItemOrderRange(List<CurriculumItemManageDetailRequest> curriculumItems) {
         curriculumItems.stream()
-                .mapToInt(CurriculumItem::getItemOrder)
+                .mapToInt(CurriculumItemManageDetailRequest::itemOrder)
                 .forEach(itemOrder -> {
                     if (itemOrder < Integer.MIN_VALUE || itemOrder > Integer.MAX_VALUE) {
                         throw new CurriculumItemException(INVALID_ITEM_ORDER);
@@ -79,9 +80,9 @@ public class CurriculumItemCommandService {
                 });
     }
 
-    private void createCurriculum(Long studyId, List<CurriculumItem> curriculumItems) {
+    private void createCurriculum(Long studyId, List<CurriculumItemManageDetailRequest> curriculumItems) {
         curriculumItems.stream()
-                .filter(curriculumItem -> !isExistsCurriculumItem(curriculumItem.getId()))
+                .filter(curriculumItem -> !isExistsCurriculumItem(curriculumItem.id()))
                 .forEach(curriculumItem -> createCurriculumItemAndAssignToParticipants(studyId, curriculumItem));
     }
 
@@ -89,13 +90,14 @@ public class CurriculumItemCommandService {
         return curriculumItemRepository.existsById(curriculumItemId);
     }
 
-    public void createCurriculumItemAndAssignToParticipants(Long studyId, CurriculumItem curriculumItem) {
+    public void createCurriculumItemAndAssignToParticipants(Long studyId,
+                                                            CurriculumItemManageDetailRequest curriculumItemRequest) {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
         List<Participant> participants = participantRepository.findAllByStudyId(studyId);
 
         CurriculumItem createCurriculumItem = CurriculumItem.builder()
-                .name(curriculumItem.getName())
-                .itemOrder(curriculumItem.getItemOrder())
+                .name(curriculumItemRequest.name())
+                .itemOrder(curriculumItemRequest.itemOrder())
                 .study(study)
                 .build();
         curriculumItemRepository.save(createCurriculumItem);
@@ -109,19 +111,20 @@ public class CurriculumItemCommandService {
         participantCurriculumItemRepository.saveAll(participantCurriculumItems);
     }
 
-    private void updateCurriculum(List<CurriculumItem> curriculumItems) {
-        for (CurriculumItem requestItem : curriculumItems) {
-            CurriculumItem existingItem = curriculumItemRepository.findById(requestItem.getId())
+
+    private void updateCurriculum(List<CurriculumItemManageDetailRequest> curriculumItems) {
+        for (CurriculumItemManageDetailRequest requestItem : curriculumItems) {
+            CurriculumItem existingItem = curriculumItemRepository.findById(requestItem.id())
                     .orElseThrow(() -> new CurriculumItemException(NOT_FOUND_CURRICULUM_ITEM));
 
-            existingItem.updateIfNameDifferent(requestItem);
-            existingItem.updateIfItemOrderDifferent(requestItem);
+            existingItem.updateIfNameDifferent(requestItem.name());
+            existingItem.updateIfItemOrderDifferent(requestItem.itemOrder());
         }
     }
 
-    private void deleteCurriculum(List<CurriculumItem> deletedCurriculumItems) {
+    private void deleteCurriculum(List<CurriculumItemManageDetailRequest> deletedCurriculumItems) {
         deletedCurriculumItems.stream()
-                .map(CurriculumItem::getId)
+                .map(CurriculumItemManageDetailRequest::id)
                 .forEach(curriculumItemRepository::deleteById);
     }
 

--- a/src/main/java/doore/study/application/dto/request/CurriculumItemManageDetailRequest.java
+++ b/src/main/java/doore/study/application/dto/request/CurriculumItemManageDetailRequest.java
@@ -1,0 +1,15 @@
+package doore.study.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record CurriculumItemManageDetailRequest(
+        @NotNull(message = "id를 입력해주세요.")
+        Long id,
+        @NotNull(message = "아이템 순서를 입력해주세요.")
+        Integer itemOrder,
+        @NotNull(message = "이름을 입력해주세요.")
+        String name
+) {
+}

--- a/src/main/java/doore/study/application/dto/request/CurriculumItemManageRequest.java
+++ b/src/main/java/doore/study/application/dto/request/CurriculumItemManageRequest.java
@@ -1,13 +1,12 @@
 package doore.study.application.dto.request;
 
-import doore.study.domain.CurriculumItem;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record CurriculumItemManageRequest(
-        List<CurriculumItem> curriculumItems,
-        List<CurriculumItem> deletedCurriculumItems
+        List<CurriculumItemManageDetailRequest> curriculumItems,
+        List<CurriculumItemManageDetailRequest> deletedCurriculumItems
 ) {
 }
 

--- a/src/main/java/doore/study/domain/CurriculumItem.java
+++ b/src/main/java/doore/study/domain/CurriculumItem.java
@@ -65,15 +65,15 @@ public class CurriculumItem extends BaseEntity {
         this.study = study;
     }
 
-    public void updateIfNameDifferent(CurriculumItem curriculumItem) {
-        if (!this.name.equals(curriculumItem.getName())) {
-            this.updateName(curriculumItem.getName());
+    public void updateIfNameDifferent(String name) {
+        if (!this.name.equals(name)) {
+            this.updateName(name);
         }
     }
 
-    public void updateIfItemOrderDifferent(CurriculumItem curriculumItem) {
-        if (!this.itemOrder.equals(curriculumItem.getItemOrder())) {
-            this.updateItemOrder(curriculumItem.getItemOrder());
+    public void updateIfItemOrderDifferent(Integer itemOrder) {
+        if (!this.itemOrder.equals(itemOrder)) {
+            this.updateItemOrder(itemOrder);
         }
     }
 }

--- a/src/main/java/doore/study/exception/CurriculumItemExceptionType.java
+++ b/src/main/java/doore/study/exception/CurriculumItemExceptionType.java
@@ -9,6 +9,7 @@ public enum CurriculumItemExceptionType implements BaseExceptionType {
 
     NOT_FOUND_CURRICULUM_ITEM(HttpStatus.NOT_FOUND, "존재하지 않는 커리큘럼입니다."),
     INVALID_ITEM_ORDER(HttpStatus.BAD_REQUEST, "유효하지 않은 아이템 순서입니다."),
+    CANNOT_CREATE_CURRICULUM_ITEM(HttpStatus.BAD_REQUEST, "커리큘럼 아이템 개수 제한을 초과하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/doore/restdocs/docs/CurriculumItemApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/CurriculumItemApiDocsTest.java
@@ -3,14 +3,17 @@ package doore.restdocs.docs;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import doore.restdocs.RestDocsTest;
 import doore.study.api.CurriculumItemController;
+import doore.study.application.dto.request.CurriculumItemManageDetailRequest;
 import doore.study.application.dto.request.CurriculumItemManageRequest;
-import doore.study.domain.CurriculumItem;
+import doore.study.domain.Study;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,10 +21,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 @WebMvcTest(CurriculumItemController.class)
 public class CurriculumItemApiDocsTest extends RestDocsTest {
     private CurriculumItemManageRequest request;
+    private Study study;
 
     @BeforeEach
     void setUp() {
@@ -31,18 +36,18 @@ public class CurriculumItemApiDocsTest extends RestDocsTest {
                 .build();
     }
 
-    private List<CurriculumItem> getCurriculumItems() {
-        List<CurriculumItem> curriculumItems = new ArrayList<>();
-        curriculumItems.add(CurriculumItem.builder().id(1L).itemOrder(1).name("Change Spring Study").build());
-        curriculumItems.add(CurriculumItem.builder().id(2L).itemOrder(4).name("CS Study").build());
-        curriculumItems.add(CurriculumItem.builder().id(3L).itemOrder(2).name("Infra Study").build());
-        curriculumItems.add(CurriculumItem.builder().id(4L).itemOrder(3).name("Algorithm Study").build());
+    private List<CurriculumItemManageDetailRequest> getCurriculumItems() {
+        List<CurriculumItemManageDetailRequest> curriculumItems = new ArrayList<>();
+        curriculumItems.add(CurriculumItemManageDetailRequest.builder().id(1L).itemOrder(1).name("Change Spring Study").build());
+        curriculumItems.add(CurriculumItemManageDetailRequest.builder().id(2L).itemOrder(4).name("CS Study").build());
+        curriculumItems.add(CurriculumItemManageDetailRequest.builder().id(3L).itemOrder(2).name("Infra Study").build());
+        curriculumItems.add(CurriculumItemManageDetailRequest.builder().id(4L).itemOrder(3).name("Algorithm Study").build());
         return curriculumItems;
     }
 
-    private List<CurriculumItem> getDeletedCurriculumItems() {
-        List<CurriculumItem> deletedCurriculumItems = new ArrayList<>();
-        deletedCurriculumItems.add(CurriculumItem.builder().id(3L).itemOrder(2).name("Infra Study").build());
+    private List<CurriculumItemManageDetailRequest> getDeletedCurriculumItems() {
+        List<CurriculumItemManageDetailRequest> deletedCurriculumItems = new ArrayList<>();
+        deletedCurriculumItems.add(CurriculumItemManageDetailRequest.builder().id(3L).itemOrder(2).name("Infra Study").build());
         return deletedCurriculumItems;
     }
 
@@ -51,11 +56,23 @@ public class CurriculumItemApiDocsTest extends RestDocsTest {
     public void manageCurriculum_커리큘럼_관리가_정상적으로_이루어진다() throws Exception {
         doNothing().when(curriculumItemCommandService).manageCurriculum(any(), any());
 
-        mockMvc.perform(post("/studies/{studyId}/curriculums", 1)
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/studies/{studyId}/curriculums", 1)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andDo(document("curriculum-manage"));
+                .andDo(document("curriculum-manage", pathParameters(
+                                parameterWithName("studyId").description("스터디 id")),
+                        requestFields(
+                                fieldWithPath("curriculumItems").description("커리큘럼 아이템 리스트"),
+                                fieldWithPath("curriculumItems[].id").description("커리큘럼 아이템 ID"),
+                                fieldWithPath("curriculumItems[].itemOrder").description("커리큘럼 아이템 순서"),
+                                fieldWithPath("curriculumItems[].name").description("커리큘럼 아이템 이름"),
+                                fieldWithPath("deletedCurriculumItems").description("삭제된 커리큘럼 아이템 리스트"),
+                                fieldWithPath("deletedCurriculumItems[].id").description("삭제된 커리큘럼 아이템 ID"),
+                                fieldWithPath("deletedCurriculumItems[].itemOrder").description("삭제된 커리큘럼 아이템 순서"),
+                                fieldWithPath("deletedCurriculumItems[].name").description("삭제된 커리큘럼 아이템 이름")
+                        )
+                ));
     }
 
     @Test
@@ -63,8 +80,12 @@ public class CurriculumItemApiDocsTest extends RestDocsTest {
     public void checkCurriculum_커리큘럼_상태가_정상적으로_변경된다() throws Exception {
         doNothing().when(curriculumItemCommandService).checkCurriculum(any(), any());
 
-        mockMvc.perform(patch("/curriculums/{curriculumId}/{participantId}/check", 1, 1))
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.patch("/curriculums/{curriculumId}/{participantId}/check", 1, 1))
                 .andExpect(status().isNoContent())
-                .andDo(document("curriculum-check"));
+                .andDo(document("curriculum-check", pathParameters(
+                        parameterWithName("curriculumId").description("커리큘럼 id"),
+                        parameterWithName("participantId").description("참여자 id")
+                )));
     }
 }

--- a/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
+++ b/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
@@ -1,5 +1,6 @@
 package doore.study.application;
 
+import static doore.study.StudyFixture.algorithmStudy;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_PARTICIPANT;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,7 +12,7 @@ import doore.member.domain.Member;
 import doore.member.domain.Participant;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.ParticipantRepository;
-import doore.study.StudyFixture;
+import doore.study.application.dto.request.CurriculumItemManageDetailRequest;
 import doore.study.application.dto.request.CurriculumItemManageRequest;
 import doore.study.domain.CurriculumItem;
 import doore.study.domain.ParticipantCurriculumItem;
@@ -52,8 +53,7 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        study = StudyFixture.algorithmStudy();
-        studyRepository.save(study);
+        study = studyRepository.save(algorithmStudy());
 
         invalidCurriculumItemId = 5L;
         invalidStudyId = 5L;
@@ -71,18 +71,22 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
                 .build();
     }
 
-    private List<CurriculumItem> getCurriculumItems() {
-        List<CurriculumItem> curriculumItems = new ArrayList<>();
-        curriculumItems.add(CurriculumItem.builder().id(1L).itemOrder(1).name("Change Spring Study").build());
-        curriculumItems.add(CurriculumItem.builder().id(2L).itemOrder(4).name("CS Study").build());
-        curriculumItems.add(CurriculumItem.builder().id(3L).itemOrder(2).name("Infra Study").build());
-        curriculumItems.add(CurriculumItem.builder().id(4L).itemOrder(3).name("Algorithm Study").build());
+    private List<CurriculumItemManageDetailRequest> getCurriculumItems() {
+        List<CurriculumItemManageDetailRequest> curriculumItems = new ArrayList<>();
+        curriculumItems.add(
+                CurriculumItemManageDetailRequest.builder().id(1L).itemOrder(1).name("Change Spring Study").build());
+        curriculumItems.add(CurriculumItemManageDetailRequest.builder().id(2L).itemOrder(4).name("CS Study").build());
+        curriculumItems.add(
+                CurriculumItemManageDetailRequest.builder().id(3L).itemOrder(2).name("Infra Study").build());
+        curriculumItems.add(
+                CurriculumItemManageDetailRequest.builder().id(4L).itemOrder(3).name("Algorithm Study").build());
         return curriculumItems;
     }
 
-    private List<CurriculumItem> getDeletedCurriculumItems() {
-        List<CurriculumItem> deletedCurriculumItems = new ArrayList<>();
-        deletedCurriculumItems.add(CurriculumItem.builder().id(3L).itemOrder(2).name("Infra Study").build());
+    private List<CurriculumItemManageDetailRequest> getDeletedCurriculumItems() {
+        List<CurriculumItemManageDetailRequest> deletedCurriculumItems = new ArrayList<>();
+        deletedCurriculumItems.add(
+                CurriculumItemManageDetailRequest.builder().id(3L).itemOrder(2).name("Infra Study").build());
         return deletedCurriculumItems;
     }
 
@@ -105,7 +109,6 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
                 .studyId(study.getId())
                 .build();
         participantRepository.save(participant);
-
         curriculumItemCommandService.manageCurriculum(request, study.getId());
         CurriculumItem curriculumItem = curriculumItemRepository.findById(4L).orElseThrow();
         curriculumItemCommandService.checkCurriculum(curriculumItem.getId(), participant.getId());
@@ -152,7 +155,7 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
         curriculumItemCommandService.manageCurriculum(request, study.getId());
         CurriculumItem resultCurriculumItem = curriculumItemRepository.findById(1L).orElseThrow();
 
-        assertThat(resultCurriculumItem.getName()).isEqualTo(request.curriculumItems().get(0).getName());
+        assertThat(resultCurriculumItem.getName()).isEqualTo(request.curriculumItems().get(0).name());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #97 
close: #111 

## 📝 작업 내용

- api 명세에 맞도록 필요한 정보만 넣어 dto를 다시 구성하였습니다.
- docs 문서에 정보를 자세하게 기입하였습니다.
- 커리큘럼의 개수가 99개라면 더 이상 커리큘럼을 추가할 수 없습니다.
- `API 목록으로 돌아가기`를 누르면 홈페이지로 이동되는 문제는 코드 문제가 아니라서 추가하지 않았습니다.
