### PR TITLE
Feature/#128 학습자료 목록 조회 rest docs api 수정

### DIFF
--- a/src/docs/asciidoc/doore.adoc
+++ b/src/docs/asciidoc/doore.adoc
@@ -10,12 +10,26 @@ endif::[]
 :toclevels: 2
 :seclinks:
 
-link:./login.html[Login API]
+## 공통
 
-link:./curriculumItem.html[CurriculumItem API]
+link:./login.html[로그인 API]
 
-link:./study.html[Study API]
+link:./member.html[회원 API]
 
-link:./team.html[Team API]
+link:./attendance.html[출석 API]
+
+link:./document.html[학습자료 API]
+
+## 스터디
+
+link:./study.html[스터디 API]
+
+link:./curriculumItem.html[커리큘럼 API]
+
+link:./participant.html[참여자 API]
+
+## 팀
+
+link:./team.html[팀 API]
 
 link:./memberTeam.html[팀원 API]

--- a/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
@@ -30,7 +30,6 @@ import doore.restdocs.RestDocsTest;
 import java.io.FileInputStream;
 import java.time.LocalDate;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
@@ -85,7 +84,6 @@ public class DocumentDocsTest extends RestDocsTest {
     }
 
     @Test
-    @Disabled //todo: Could not write JSON 오류 해결
     @DisplayName("학습자료 목록을 조회한다.")
     public void 학습자료_목록을_조회한다() throws Exception {
         //given
@@ -94,8 +92,7 @@ public class DocumentDocsTest extends RestDocsTest {
         DocumentCondensedResponse otherDocumentCondensedResponse =
                 new DocumentCondensedResponse(2L, "학습자료2", "학습자료2 입니다.", LocalDate.parse("2020-02-03"), 2L);
         Page<DocumentCondensedResponse> documentCondensedResponses = new PageImpl<>(
-                List.of(documentCondensedResponse, otherDocumentCondensedResponse));
-
+                List.of(documentCondensedResponse, otherDocumentCondensedResponse), PageRequest.of(0,4),2);
         //when
         when(documentQueryService.getAllDocument(any(), any(), any(PageRequest.class)))
                 .thenReturn(documentCondensedResponses);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #128

## 📝 작업 내용

학습자료 목록 조회 restDosc 테스트시 could not write Json 에러가 발생하는 것을 해결
-> Page 타입의 response 데이터에 pageable 추가
