### PR TITLE
Feature/#124 팀 삭제 시 연관된 스터디와 커리큘럼도 삭제된다

### DIFF
--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -161,9 +161,7 @@ public class CurriculumItemCommandService {
         deletedCurriculumItems.stream()
                 .map(CurriculumItemManageDetailRequest::id)
                 .forEach(curriculumItemId -> {
-                    List<ParticipantCurriculumItem> items = participantCurriculumItemRepository.findAllByCurriculumItemId(
-                            curriculumItemId);
-                    items.forEach(ParticipantCurriculumItem::delete);
+                    participantCurriculumItemRepository.deleteAllByCurriculumItemId(curriculumItemId);
                     curriculumItemRepository.deleteById(curriculumItemId);
                 });
     }

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -163,7 +163,7 @@ public class CurriculumItemCommandService {
                 .forEach(curriculumItemId -> {
                     List<ParticipantCurriculumItem> items = participantCurriculumItemRepository.findAllByCurriculumItemId(
                             curriculumItemId);
-                    items.forEach(ParticipantCurriculumItem::isDelete);
+                    items.forEach(ParticipantCurriculumItem::delete);
                     curriculumItemRepository.deleteById(curriculumItemId);
                 });
     }

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -160,7 +160,12 @@ public class CurriculumItemCommandService {
     private void deleteCurriculum(List<CurriculumItemManageDetailRequest> deletedCurriculumItems) {
         deletedCurriculumItems.stream()
                 .map(CurriculumItemManageDetailRequest::id)
-                .forEach(curriculumItemRepository::deleteById);
+                .forEach(curriculumItemId -> {
+                    List<ParticipantCurriculumItem> items = participantCurriculumItemRepository.findAllByCurriculumItemId(
+                            curriculumItemId);
+                    items.forEach(ParticipantCurriculumItem::isDelete);
+                    curriculumItemRepository.deleteById(curriculumItemId);
+                });
     }
 
     private void sortCurriculum() {
@@ -174,7 +179,7 @@ public class CurriculumItemCommandService {
     private void validateExistStudyLeader(Long memberId) {
         StudyRole studyRole = studyRoleRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!studyRole.getStudyRoleType().equals(ROLE_스터디장)){
+        if (!studyRole.getStudyRoleType().equals(ROLE_스터디장)) {
             throw new MemberException(UNAUTHORIZED);
         }
     }
@@ -182,7 +187,7 @@ public class CurriculumItemCommandService {
     private void validateExistStudyLeaderAndStudyMember(Long memberId) {
         StudyRole studyRole = studyRoleRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!(studyRole.getStudyRoleType().equals(ROLE_스터디장) || studyRole.getStudyRoleType().equals(ROLE_스터디원))){
+        if (!(studyRole.getStudyRoleType().equals(ROLE_스터디장) || studyRole.getStudyRoleType().equals(ROLE_스터디원))) {
             throw new MemberException(UNAUTHORIZED);
         }
     }

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -164,7 +164,6 @@ public class CurriculumItemCommandService {
                     List<ParticipantCurriculumItem> items = participantCurriculumItemRepository.findAllByCurriculumItemId(
                             curriculumItemId);
                     items.forEach(ParticipantCurriculumItem::isDelete);
-                    curriculumItemRepository.deleteById(curriculumItemId);
                 });
     }
 

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -164,6 +164,7 @@ public class CurriculumItemCommandService {
                     List<ParticipantCurriculumItem> items = participantCurriculumItemRepository.findAllByCurriculumItemId(
                             curriculumItemId);
                     items.forEach(ParticipantCurriculumItem::isDelete);
+                    curriculumItemRepository.deleteById(curriculumItemId);
                 });
     }
 

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -15,14 +15,18 @@ import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.exception.MemberException;
 import doore.study.application.dto.request.StudyCreateRequest;
 import doore.study.application.dto.request.StudyUpdateRequest;
+import doore.study.domain.CurriculumItem;
+import doore.study.domain.ParticipantCurriculumItem;
 import doore.study.domain.Study;
-
-import doore.study.domain.repository.StudyRepository;
 import doore.study.domain.StudyStatus;
+import doore.study.domain.repository.CurriculumItemRepository;
+import doore.study.domain.repository.ParticipantCurriculumItemRepository;
+import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
 import doore.team.domain.TeamRepository;
 import doore.team.exception.TeamException;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +39,8 @@ public class StudyCommandService {
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
     private final StudyRoleRepository studyRoleRepository;
+    private final CurriculumItemRepository curriculumItemRepository;
+    private final ParticipantCurriculumItemRepository participantCurriculumItemRepository;
 
     public void createStudy(final StudyCreateRequest request, final Long teamId, final Long memberId) {
         validateExistMember(memberId);
@@ -57,7 +63,19 @@ public class StudyCommandService {
     public void deleteStudy(Long studyId, Long memberId) {
         validateExistStudyLeader(memberId);
         validateExistStudy(studyId);
+
+        List<CurriculumItem> curriculumItems = curriculumItemRepository.findAllByStudyId(studyId);
+        List<Long> curriculumItemIds = curriculumItems.stream()
+                .map(CurriculumItem::getId)
+                .toList();
+
+        curriculumItemIds.forEach(curriculumItemId -> {
+            List<ParticipantCurriculumItem> items = participantCurriculumItemRepository.findAllByCurriculumItemId(curriculumItemId);
+            items.forEach(ParticipantCurriculumItem::isDelete);
+        });
+
         studyRepository.deleteById(studyId);
+        curriculumItemRepository.deleteAllByStudyId(studyId);
     }
 
     public void updateStudy(StudyUpdateRequest request, Long studyId, Long memberId) {
@@ -98,7 +116,7 @@ public class StudyCommandService {
     private void validateExistStudyLeader(Long memberId) {
         StudyRole studyRole = studyRoleRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!studyRole.getStudyRoleType().equals(ROLE_스터디장)){
+        if (!studyRole.getStudyRoleType().equals(ROLE_스터디장)) {
             throw new MemberException(UNAUTHORIZED);
         }
     }

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -69,11 +69,11 @@ public class StudyCommandService {
                 .map(CurriculumItem::getId)
                 .toList();
 
-        curriculumItems.forEach(CurriculumItem::isDelete);
+        curriculumItems.forEach(CurriculumItem::delete);
 
         curriculumItemIds.forEach(curriculumItemId -> {
             List<ParticipantCurriculumItem> items = participantCurriculumItemRepository.findAllByCurriculumItemId(curriculumItemId);
-            items.forEach(ParticipantCurriculumItem::isDelete);
+            items.forEach(ParticipantCurriculumItem::delete);
         });
 
         studyRepository.deleteById(studyId);

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -69,13 +69,14 @@ public class StudyCommandService {
                 .map(CurriculumItem::getId)
                 .toList();
 
+        curriculumItems.forEach(CurriculumItem::isDelete);
+
         curriculumItemIds.forEach(curriculumItemId -> {
             List<ParticipantCurriculumItem> items = participantCurriculumItemRepository.findAllByCurriculumItemId(curriculumItemId);
             items.forEach(ParticipantCurriculumItem::isDelete);
         });
 
         studyRepository.deleteById(studyId);
-        curriculumItemRepository.deleteAllByStudyId(studyId);
     }
 
     public void updateStudy(StudyUpdateRequest request, Long studyId, Long memberId) {

--- a/src/main/java/doore/study/domain/CurriculumItem.java
+++ b/src/main/java/doore/study/domain/CurriculumItem.java
@@ -16,14 +16,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Where(clause = "is_deleted = false")
-@SQLDelete(sql = "UPDATE CurriculumItem SET is_deleted = true where id = ?")
 public class CurriculumItem extends BaseEntity {
 
     @Id

--- a/src/main/java/doore/study/domain/CurriculumItem.java
+++ b/src/main/java/doore/study/domain/CurriculumItem.java
@@ -75,7 +75,7 @@ public class CurriculumItem extends BaseEntity {
         }
     }
 
-    public void isDelete() {
+    public void delete() {
         this.isDeleted = true;
     }
 }

--- a/src/main/java/doore/study/domain/CurriculumItem.java
+++ b/src/main/java/doore/study/domain/CurriculumItem.java
@@ -16,10 +16,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "is_deleted = false")
+@SQLDelete(sql = "UPDATE CurriculumItem SET is_deleted = true where id = ?")
 public class CurriculumItem extends BaseEntity {
 
     @Id

--- a/src/main/java/doore/study/domain/CurriculumItem.java
+++ b/src/main/java/doore/study/domain/CurriculumItem.java
@@ -1,7 +1,5 @@
 package doore.study.domain;
 
-import static jakarta.persistence.CascadeType.REMOVE;
-
 import doore.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,7 +39,7 @@ public class CurriculumItem extends BaseEntity {
     @JoinColumn(name = "study_id", nullable = false)
     private Study study;
 
-    @OneToMany(mappedBy = "curriculumItem", cascade = REMOVE)
+    @OneToMany(mappedBy = "curriculumItem")
     private final List<ParticipantCurriculumItem> participantCurriculumItems = new ArrayList<>();
 
     @Builder
@@ -75,5 +73,9 @@ public class CurriculumItem extends BaseEntity {
         if (!this.itemOrder.equals(itemOrder)) {
             this.updateItemOrder(itemOrder);
         }
+    }
+
+    public void isDelete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/doore/study/domain/ParticipantCurriculumItem.java
+++ b/src/main/java/doore/study/domain/ParticipantCurriculumItem.java
@@ -13,11 +13,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
-@Where(clause = "is_deleted = false" )
+@Where(clause = "is_deleted = false")
+@SQLDelete(sql = "UPDATE ParticipantCurriculumItem SET is_deleted = true where id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ParticipantCurriculumItem extends BaseEntity {
 
@@ -60,5 +62,9 @@ public class ParticipantCurriculumItem extends BaseEntity {
         } else {
             complete();
         }
+    }
+
+    public void isDelete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/doore/study/domain/ParticipantCurriculumItem.java
+++ b/src/main/java/doore/study/domain/ParticipantCurriculumItem.java
@@ -13,13 +13,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
 @Where(clause = "is_deleted = false")
-@SQLDelete(sql = "UPDATE ParticipantCurriculumItem SET is_deleted = true where id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ParticipantCurriculumItem extends BaseEntity {
 

--- a/src/main/java/doore/study/domain/ParticipantCurriculumItem.java
+++ b/src/main/java/doore/study/domain/ParticipantCurriculumItem.java
@@ -64,7 +64,7 @@ public class ParticipantCurriculumItem extends BaseEntity {
         }
     }
 
-    public void isDelete() {
+    public void delete() {
         this.isDeleted = true;
     }
 }

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -95,7 +95,7 @@ public class Study extends BaseEntity {
         this.status = status;
     }
 
-    public void isDelete() {
+    public void delete() {
         this.isDeleted = true;
     }
 }

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -1,7 +1,6 @@
 package doore.study.domain;
 
 import static doore.study.domain.StudyStatus.ENDED;
-import static jakarta.persistence.CascadeType.REMOVE;
 
 import doore.base.BaseEntity;
 import jakarta.persistence.Column;
@@ -56,7 +55,7 @@ public class Study extends BaseEntity {
     @Column(nullable = false)
     private Long cropId;
 
-    @OneToMany(mappedBy = "study", cascade = REMOVE)
+    @OneToMany(mappedBy = "study")
     private final List<CurriculumItem> curriculumItems = new ArrayList<>();
 
     @Builder

--- a/src/main/java/doore/study/domain/Study.java
+++ b/src/main/java/doore/study/domain/Study.java
@@ -94,4 +94,8 @@ public class Study extends BaseEntity {
     public void changeStatus(StudyStatus status) {
         this.status = status;
     }
+
+    public void isDelete() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
+++ b/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
@@ -8,4 +8,6 @@ public interface CurriculumItemRepository extends JpaRepository<CurriculumItem, 
     List<CurriculumItem> findAllByOrderByItemOrderAsc();
 
     List<CurriculumItem> findAllByStudyId(Long studyId);
+
+    void deleteAllByStudyId(Long studyId);
 }

--- a/src/main/java/doore/study/domain/repository/ParticipantCurriculumItemRepository.java
+++ b/src/main/java/doore/study/domain/repository/ParticipantCurriculumItemRepository.java
@@ -16,4 +16,8 @@ public interface ParticipantCurriculumItemRepository extends JpaRepository<Parti
             + "where m.id = :memberId "
             + "and c.study.id = :studyId ")
     List<ParticipantCurriculumItem> findAllByStudyIdAndMemberId(Long studyId, Long memberId);
+
+    List<ParticipantCurriculumItem> findAllByCurriculumItemId(Long curriculumId);
+
+    void deleteAllByCurriculumItemId(Long curriculumItemId);
 }

--- a/src/main/java/doore/team/application/TeamCommandService.java
+++ b/src/main/java/doore/team/application/TeamCommandService.java
@@ -166,14 +166,14 @@ public class TeamCommandService {
         List<Study> studies = studyRepository.findAllByTeamId(teamId);
 
         studies.forEach(study -> {
-            study.isDelete();
+            study.delete();
             List<CurriculumItem> curriculumItems = curriculumItemRepository.findAllByStudyId(study.getId());
 
             curriculumItems.forEach(curriculumItem -> {
-                curriculumItem.isDelete();
+                curriculumItem.delete();
                 List<ParticipantCurriculumItem> participantCurriculumItems = participantCurriculumItemRepository.findAllByCurriculumItemId(
                         curriculumItem.getId());
-                participantCurriculumItems.forEach(ParticipantCurriculumItem::isDelete);
+                participantCurriculumItems.forEach(ParticipantCurriculumItem::delete);
             });
         });
     }

--- a/src/main/java/doore/team/application/TeamCommandService.java
+++ b/src/main/java/doore/team/application/TeamCommandService.java
@@ -15,6 +15,12 @@ import doore.member.domain.TeamRole;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.TeamRoleRepository;
 import doore.member.exception.MemberException;
+import doore.study.domain.CurriculumItem;
+import doore.study.domain.ParticipantCurriculumItem;
+import doore.study.domain.Study;
+import doore.study.domain.repository.CurriculumItemRepository;
+import doore.study.domain.repository.ParticipantCurriculumItemRepository;
+import doore.study.domain.repository.StudyRepository;
 import doore.team.application.dto.request.TeamCreateRequest;
 import doore.team.application.dto.request.TeamInviteCodeRequest;
 import doore.team.application.dto.request.TeamUpdateRequest;
@@ -24,6 +30,7 @@ import doore.team.domain.TeamRepository;
 import doore.team.exception.TeamException;
 import doore.util.RandomUtil;
 import doore.util.RedisUtil;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -38,6 +45,9 @@ public class TeamCommandService {
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
     private final TeamRoleRepository teamRoleRepository;
+    private final StudyRepository studyRepository;
+    private final CurriculumItemRepository curriculumItemRepository;
+    private final ParticipantCurriculumItemRepository participantCurriculumItemRepository;
     private final S3ImageFileService s3ImageFileService;
     private final RedisUtil redisUtil;
 
@@ -91,8 +101,7 @@ public class TeamCommandService {
         if (team.hasImage()) {
             s3ImageFileService.deleteFile(team.getImageUrl());
         }
-        // TODO: 2/2/24 팀이 삭제될 시 연관된 스터디와, 커리큘럼도 삭제
-
+        deleteStudyAndCurriculumItemAndParticipantCurriculumItem(teamId);
     }
 
     private Team validateExistTeam(final Long teamId) {
@@ -151,5 +160,21 @@ public class TeamCommandService {
 
     private void duplicateCheckTeamMember(final Long memberId) {
         teamRoleRepository.findById(memberId).orElseThrow(() -> new MemberException(ALREADY_JOIN_TEAM_MEMBER));
+    }
+
+    private void deleteStudyAndCurriculumItemAndParticipantCurriculumItem(final Long teamId) {
+        List<Study> studies = studyRepository.findAllByTeamId(teamId);
+
+        studies.forEach(study -> {
+            study.isDelete();
+            List<CurriculumItem> curriculumItems = curriculumItemRepository.findAllByStudyId(study.getId());
+
+            curriculumItems.forEach(curriculumItem -> {
+                curriculumItem.isDelete();
+                List<ParticipantCurriculumItem> participantCurriculumItems = participantCurriculumItemRepository.findAllByCurriculumItemId(
+                        curriculumItem.getId());
+                participantCurriculumItems.forEach(ParticipantCurriculumItem::isDelete);
+            });
+        });
     }
 }

--- a/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
+++ b/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
@@ -255,7 +255,7 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
         List<ParticipantCurriculumItem> result = participantCurriculumItemRepository.findAllByCurriculumItemId(
                 curriculumItem3.getId());
 
-        assertThat(result.size()).isEqualTo(0);
+        assertThat(result).isEmpty();
     }
 
     @Test

--- a/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
+++ b/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
@@ -239,6 +239,26 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("[성공] 커리큘럼을 삭제하면 커리큘럼 아이템도 삭제된다.")
+    public void deleteCurriculum_커리큘럼을_삭제하면_커리큘럼_아이템도_삭제된다() throws Exception {
+        ParticipantCurriculumItem participantCurriculumItem = ParticipantCurriculumItem.builder()
+                .participantId(1L)
+                .curriculumItem(curriculumItem3)
+                .build();
+        participantCurriculumItemRepository.save(participantCurriculumItem);
+        List<ParticipantCurriculumItem> before = participantCurriculumItemRepository.findAllByCurriculumItemId(
+                curriculumItem3.getId());
+
+        assertThat(before.size()).isEqualTo(1);
+
+        curriculumItemCommandService.manageCurriculum(request, study.getId(), memberId);
+        List<ParticipantCurriculumItem> result = participantCurriculumItemRepository.findAllByCurriculumItemId(
+                curriculumItem3.getId());
+
+        assertThat(result.size()).isEqualTo(0);
+    }
+
+    @Test
     @DisplayName("[성공] 모든 과정이 끝나면 아이템 순서에 대해 연속적인 오름차순으로 정렬된다.")
     public void sortCurriculum_모든_과정이_끝나면_아이템_순서에_대해_연속적인_오름차순으로_정렬된다() throws Exception {
         curriculumItemCommandService.manageCurriculum(request, study.getId(), memberId);

--- a/src/test/java/doore/study/application/StudyCommandServiceTest.java
+++ b/src/test/java/doore/study/application/StudyCommandServiceTest.java
@@ -220,7 +220,8 @@ public class StudyCommandServiceTest extends IntegrationTest {
                 List<CurriculumItem> afterCurriculumItems = curriculumItemRepository.findAllByStudyId(study.getId());
 
                 assertThat(beforeCurriculumItems.size()).isEqualTo(2);
-                assertThat(afterCurriculumItems).isEmpty();
+                assertThat(afterCurriculumItems.get(0).getIsDeleted()).isEqualTo(true);
+                assertThat(afterCurriculumItems.get(1).getIsDeleted()).isEqualTo(true);
             }
 
             @Test

--- a/src/test/java/doore/study/application/StudyCommandServiceTest.java
+++ b/src/test/java/doore/study/application/StudyCommandServiceTest.java
@@ -221,7 +221,7 @@ public class StudyCommandServiceTest extends IntegrationTest {
                 List<CurriculumItem> afterCurriculumItems = curriculumItemRepository.findAll();
 
                 assertThat(beforeCurriculumItems.size()).isEqualTo(2);
-                assertTrue(afterCurriculumItems.isEmpty());
+                assertThat(afterCurriculumItems).isEmpty();
             }
 
             @Test

--- a/src/test/java/doore/study/application/StudyCommandServiceTest.java
+++ b/src/test/java/doore/study/application/StudyCommandServiceTest.java
@@ -181,7 +181,6 @@ public class StudyCommandServiceTest extends IntegrationTest {
             private Member member1;
             private Member member2;
 
-
             @BeforeEach
             void setUp() {
                 member1 = memberRepository.save(보름());

--- a/src/test/java/doore/study/application/StudyCommandServiceTest.java
+++ b/src/test/java/doore/study/application/StudyCommandServiceTest.java
@@ -1,7 +1,9 @@
 package doore.study.application;
 
 import static doore.member.MemberFixture.미나;
+import static doore.member.MemberFixture.보름;
 import static doore.member.MemberFixture.아마란스;
+import static doore.member.MemberFixture.짱구;
 import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.member.domain.StudyRoleType.ROLE_스터디장;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
@@ -22,14 +24,20 @@ import static org.mockito.Mockito.mock;
 
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
+import doore.member.domain.Participant;
 import doore.member.domain.StudyRole;
 import doore.member.domain.repository.MemberRepository;
+import doore.member.domain.repository.ParticipantRepository;
 import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.exception.MemberException;
 import doore.study.application.dto.request.StudyCreateRequest;
 import doore.study.application.dto.request.StudyUpdateRequest;
+import doore.study.domain.CurriculumItem;
+import doore.study.domain.ParticipantCurriculumItem;
 import doore.study.domain.Study;
 import doore.study.domain.StudyStatus;
+import doore.study.domain.repository.CurriculumItemRepository;
+import doore.study.domain.repository.ParticipantCurriculumItemRepository;
 import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
 import doore.team.domain.Team;
@@ -57,6 +65,12 @@ public class StudyCommandServiceTest extends IntegrationTest {
     private TeamRepository teamRepository;
     @Autowired
     private StudyRoleRepository studyRoleRepository;
+    @Autowired
+    private CurriculumItemRepository curriculumItemRepository;
+    @Autowired
+    private ParticipantCurriculumItemRepository participantCurriculumItemRepository;
+    @Autowired
+    private ParticipantRepository participantRepository;
 
     private Long memberId;
     private StudyRole studyRole;
@@ -155,14 +169,73 @@ public class StudyCommandServiceTest extends IntegrationTest {
             }
         }
 
-        @Test
-        @DisplayName("[성공] 정상적으로 스터디를 삭제할 수 있다.")
-        void deleteStudy_정상적으로_스터디를_삭제할_수_있다() throws Exception {
-            studyCommandService.deleteStudy(study.getId(), memberId);
-            List<Study> studies = studyRepository.findAll();
-            assertTrue(studies.get(0).getIsDeleted());
-        }
+        @Nested
+        @DisplayName("스터디 삭제 테스트")
+        class StudyDeleteTest {
+            private CurriculumItem curriculumItem1;
+            private CurriculumItem curriculumItem2;
+            private ParticipantCurriculumItem participantCurriculumItem1;
+            private ParticipantCurriculumItem participantCurriculumItem2;
+            private Participant participant1;
+            private Participant participant2;
+            private Member member1;
+            private Member member2;
 
+
+            @BeforeEach
+            void setUp() {
+                member1 = memberRepository.save(보름());
+                member2 = memberRepository.save(짱구());
+                participant1 = participantRepository.save(
+                        Participant.builder().studyId(study.getId()).member(member1).build());
+                participant2 = participantRepository.save(
+                        Participant.builder().studyId(study.getId()).member(member2).build());
+                curriculumItem1 = curriculumItemRepository.save(
+                        CurriculumItem.builder().id(1L).name("커리1").itemOrder(1).study(study).build());
+                curriculumItem2 = curriculumItemRepository.save(
+                        CurriculumItem.builder().id(2L).name("커리2").itemOrder(2).study(study).build());
+                participantCurriculumItem1 = participantCurriculumItemRepository.save(
+                        ParticipantCurriculumItem.builder().participantId(member1.getId())
+                                .curriculumItem(curriculumItem1)
+                                .build());
+                participantCurriculumItem2 = participantCurriculumItemRepository.save(
+                        ParticipantCurriculumItem.builder().participantId(member2.getId())
+                                .curriculumItem(curriculumItem2)
+                                .build());
+            }
+
+            @Test
+            @DisplayName("[성공] 정상적으로 스터디를 제할 수 있다.")
+            void deleteStudy_정상적으로_스터디를_삭제할_수_있다_성공() throws Exception {
+                studyCommandService.deleteStudy(study.getId(), memberId);
+                List<Study> studies = studyRepository.findAll();
+                assertTrue(studies.get(0).getIsDeleted());
+            }
+
+            @Test
+            @DisplayName("[성공] 스터디가 삭제되면 커리큘럼이 모두 삭제된다.")
+            void deleteStudy_스터디가_삭제되면_커리큘럼이_모두_삭제된다_성공() throws Exception {
+                List<CurriculumItem> beforeCurriculumItems = curriculumItemRepository.findAll();
+
+                studyCommandService.deleteStudy(study.getId(), memberId);
+                List<CurriculumItem> afterCurriculumItems = curriculumItemRepository.findAll();
+
+                assertThat(beforeCurriculumItems.size()).isEqualTo(2);
+                assertTrue(afterCurriculumItems.isEmpty());
+            }
+
+            @Test
+            @DisplayName("[성공] 스터디가 삭제되면 참여자 커리큘럼이 모두 삭제된다.")
+            void deleteStudy_스터디가_삭제되면_참여자_커리큘럼이_모두_삭제된다_성공() throws Exception {
+                List<ParticipantCurriculumItem> beforeParticipantCurriculumItem = participantCurriculumItemRepository.findAll();
+
+                studyCommandService.deleteStudy(study.getId(), memberId);
+                List<ParticipantCurriculumItem> afterParticipantCurriculumItem = participantCurriculumItemRepository.findAll();
+
+                assertThat(beforeParticipantCurriculumItem.size()).isEqualTo(2);
+                assertThat(afterParticipantCurriculumItem).isEmpty();
+            }
+        }
 
         @Nested
         @DisplayName("스터디 종료 테스트")

--- a/src/test/java/doore/study/application/StudyCommandServiceTest.java
+++ b/src/test/java/doore/study/application/StudyCommandServiceTest.java
@@ -214,10 +214,10 @@ public class StudyCommandServiceTest extends IntegrationTest {
             @Test
             @DisplayName("[성공] 스터디가 삭제되면 커리큘럼이 모두 삭제된다.")
             void deleteStudy_스터디가_삭제되면_커리큘럼이_모두_삭제된다_성공() throws Exception {
-                List<CurriculumItem> beforeCurriculumItems = curriculumItemRepository.findAll();
+                List<CurriculumItem> beforeCurriculumItems = curriculumItemRepository.findAllByStudyId(study.getId());
 
                 studyCommandService.deleteStudy(study.getId(), memberId);
-                List<CurriculumItem> afterCurriculumItems = curriculumItemRepository.findAll();
+                List<CurriculumItem> afterCurriculumItems = curriculumItemRepository.findAllByStudyId(study.getId());
 
                 assertThat(beforeCurriculumItems.size()).isEqualTo(2);
                 assertThat(afterCurriculumItems).isEmpty();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #124

## 📝 작업 내용
- 팀이 삭제되면 스터디, 커리큘럼, 참여자 커리큘럼이 삭제됩니다.
- 스터디가 삭제되면 커리큘럼, 참여자 커리큘럼이 삭제됩니다.
- 커리큘럼이 삭제되면 참여자 커리큘럼이 삭제됩니다.

## 💬 리뷰 요구사항
- 원래 있던 코드는 그대로 두고, 이번 작업 내용만 soft Delete로 작성하였습니다. 다른 코드는 #98 에서 해결하는게 작업 단위가 맞을 것 같습니다!
- Disabled 되어있는 코드는 S3 문제로 통과 못해서 처리해두었습니다~
