### PR TITLE
Feature/#127 팀 상세 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/team.adoc
+++ b/src/docs/asciidoc/team.adoc
@@ -111,3 +111,17 @@ include::{snippets}/my-teams/http-response.adoc[]
 
 .Response Body's Fields
 include::{snippets}/my-teams/response-fields.adoc[]
+
+== `GET`: 팀 상세 조회
+
+.HTTP Request
+include::{snippets}/get-team/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/get-team/path-parameters.adoc[]
+
+.HTTP Response
+include::{snippets}/get-team/http-response.adoc[]
+
+.Response Body's Fields
+include::{snippets}/get-team/response-fields.adoc[]

--- a/src/main/java/doore/attendance/domain/repository/AttendanceRepository.java
+++ b/src/main/java/doore/attendance/domain/repository/AttendanceRepository.java
@@ -2,6 +2,7 @@ package doore.attendance.domain.repository;
 
 import doore.attendance.domain.Attendance;
 import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,4 +10,6 @@ import org.springframework.data.repository.query.Param;
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     @Query(value = "select count(*)>0 from Attendance a where a.memberId= :memberId and DATE(a.createdAt)=:date")
     Boolean existsByMemberIdAndDate(@Param("memberId")Long memberId, @Param("date")LocalDate date);
+
+    List<Attendance> findAllByMemberIdIn(List<Long> memberIds);
 }

--- a/src/main/java/doore/team/api/TeamController.java
+++ b/src/main/java/doore/team/api/TeamController.java
@@ -10,6 +10,7 @@ import doore.team.application.dto.request.TeamUpdateRequest;
 import doore.team.application.dto.response.MyTeamsAndStudiesResponse;
 import doore.team.application.dto.response.TeamInviteCodeResponse;
 import doore.team.application.dto.response.TeamReferenceResponse;
+import doore.team.application.dto.response.TeamResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -103,5 +104,10 @@ public class TeamController {
     public ResponseEntity<List<MyTeamsAndStudiesResponse>> getMyTeamsAndStudies(@PathVariable final Long memberId,
                                                                                 @LoginMember Member member) {
         return ResponseEntity.ok(teamQueryService.findMyTeamsAndStudies(memberId, member.getId()));
+    }
+
+    @GetMapping("/{teamId}") // 비회원
+    public ResponseEntity<TeamResponse> getTeam(@PathVariable final Long teamId) {
+        return ResponseEntity.ok(teamQueryService.findTeamByTeamId(teamId));
     }
 }

--- a/src/main/java/doore/team/application/TeamQueryService.java
+++ b/src/main/java/doore/team/application/TeamQueryService.java
@@ -4,8 +4,12 @@ import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
+import doore.attendance.domain.Attendance;
 import doore.attendance.domain.repository.AttendanceRepository;
+import doore.member.domain.Member;
+import doore.member.domain.MemberTeam;
 import doore.member.domain.repository.MemberRepository;
+import doore.member.domain.repository.MemberTeamRepository;
 import doore.member.exception.MemberException;
 import doore.study.application.dto.response.StudyNameResponse;
 import doore.study.domain.repository.StudyRepository;
@@ -29,6 +33,7 @@ public class TeamQueryService {
     private final MemberRepository memberRepository;
     private final StudyRepository studyRepository;
     private final AttendanceRepository attendanceRepository;
+    private final MemberTeamRepository memberTeamRepository;
 
     public List<TeamReferenceResponse> findMyTeams(final Long memberId, final Long tokenMemberId) {
         validateMember(memberId);
@@ -59,9 +64,18 @@ public class TeamQueryService {
 
     public TeamResponse findTeamByTeamId(final Long teamId) {
         Team team = teamRepository.findById(teamId).orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
-        Long countTeamMember = 2L;
-        Long countAttendanceTrueMember = 1L;
-        Long attendanceRatio = 50L;
+        List<MemberTeam> memberTeams = memberTeamRepository.findAllByTeamId(teamId);
+        List<Long> memberIds = memberTeams.stream()
+                .map(MemberTeam::getMember)
+                .map(Member::getId)
+                .toList();
+
+        List<Attendance> attendances = attendanceRepository.findAllByMemberIdIn(memberIds);
+
+        long countMemberTeam = memberIds.size();
+        long countAttendanceMemberTeam = attendances.size();
+        long attendanceRatio = countMemberTeam > 0 ? (long)((countAttendanceMemberTeam * 100.0) / countMemberTeam) : 0;
+
         return TeamResponse.of(team, attendanceRatio);
     }
 

--- a/src/main/java/doore/team/application/TeamQueryService.java
+++ b/src/main/java/doore/team/application/TeamQueryService.java
@@ -2,15 +2,19 @@ package doore.team.application;
 
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+import static doore.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
+import doore.attendance.domain.repository.AttendanceRepository;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.exception.MemberException;
 import doore.study.application.dto.response.StudyNameResponse;
 import doore.study.domain.repository.StudyRepository;
 import doore.team.application.dto.response.MyTeamsAndStudiesResponse;
 import doore.team.application.dto.response.TeamReferenceResponse;
+import doore.team.application.dto.response.TeamResponse;
 import doore.team.domain.Team;
 import doore.team.domain.TeamRepository;
+import doore.team.exception.TeamException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +28,7 @@ public class TeamQueryService {
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
     private final StudyRepository studyRepository;
+    private final AttendanceRepository attendanceRepository;
 
     public List<TeamReferenceResponse> findMyTeams(final Long memberId, final Long tokenMemberId) {
         validateMember(memberId);
@@ -50,6 +55,14 @@ public class TeamQueryService {
             myTeamsAndStudiesResponses.add(myTeamsAndStudiesResponse);
         }
         return myTeamsAndStudiesResponses;
+    }
+
+    public TeamResponse findTeamByTeamId(final Long teamId) {
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
+        Long countTeamMember = 2L;
+        Long countAttendanceTrueMember = 1L;
+        Long attendanceRatio = 50L;
+        return TeamResponse.of(team, attendanceRatio);
     }
 
     private void validateMember(final Long memberId) {

--- a/src/main/java/doore/team/application/dto/response/TeamResponse.java
+++ b/src/main/java/doore/team/application/dto/response/TeamResponse.java
@@ -1,0 +1,23 @@
+package doore.team.application.dto.response;
+
+import doore.team.domain.Team;
+import lombok.Builder;
+
+@Builder
+public record TeamResponse(
+        Long id,
+        String name,
+        String description,
+        String imageUrl,
+        Long attendanceRatio
+) {
+    public static TeamResponse of(final Team team, final Long attendanceRatio) {
+        return TeamResponse.builder()
+                .id(team.getId())
+                .name(team.getName())
+                .description(team.getDescription())
+                .imageUrl(team.getImageUrl())
+                .attendanceRatio(attendanceRatio)
+                .build();
+    }
+}

--- a/src/main/java/doore/team/application/dto/response/TeamResponse.java
+++ b/src/main/java/doore/team/application/dto/response/TeamResponse.java
@@ -9,9 +9,9 @@ public record TeamResponse(
         String name,
         String description,
         String imageUrl,
-        Long attendanceRatio
+        long attendanceRatio
 ) {
-    public static TeamResponse of(final Team team, final Long attendanceRatio) {
+    public static TeamResponse of(final Team team, final long attendanceRatio) {
         return TeamResponse.builder()
                 .id(team.getId())
                 .name(team.getName())

--- a/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
@@ -286,7 +286,7 @@ public class TeamApiDocsTest extends RestDocsTest {
     void 팀_상세목록을_조회한다() throws Exception {
         final Long teamId = 1L;
 
-        final TeamResponse teamResponse = new TeamResponse(1L, "팀 이름", "팀 설명", "1234", 50L);
+        final TeamResponse teamResponse = new TeamResponse(1L, "팀 이름", "팀 설명", "1234", 50);
         final PathParametersSnippet pathParameters = pathParameters(
                 parameterWithName("teamId").description("조회하고자 하는 팀 ID")
         );

--- a/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
@@ -27,6 +27,7 @@ import doore.team.application.dto.request.TeamUpdateRequest;
 import doore.team.application.dto.response.MyTeamsAndStudiesResponse;
 import doore.team.application.dto.response.TeamInviteCodeResponse;
 import doore.team.application.dto.response.TeamReferenceResponse;
+import doore.team.application.dto.response.TeamResponse;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -252,8 +253,8 @@ public class TeamApiDocsTest extends RestDocsTest {
         final Long memberId = 1L;
         final Long tokenMemberId = 1L;
         final List<StudyNameResponse> studyResponses = List.of(
-                 new StudyNameResponse(1L, "알고리즘 스터디"),
-                new StudyNameResponse(2L,"개발 스터디")
+                new StudyNameResponse(1L, "알고리즘 스터디"),
+                new StudyNameResponse(2L, "개발 스터디")
         );
         final List<MyTeamsAndStudiesResponse> response = List.of(
                 new MyTeamsAndStudiesResponse(1L, "BDD", studyResponses)
@@ -278,5 +279,31 @@ public class TeamApiDocsTest extends RestDocsTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(document("my-teams-and-studies", pathParameters, responseFieldsSnippet));
+    }
+
+    @Test
+    @DisplayName("팀 상세목록을 조회한다.")
+    void 팀_상세목록을_조회한다() throws Exception {
+        final Long teamId = 1L;
+
+        final TeamResponse teamResponse = new TeamResponse(1L, "팀 이름", "팀 설명", "1234", 50L);
+        final PathParametersSnippet pathParameters = pathParameters(
+                parameterWithName("teamId").description("조회하고자 하는 팀 ID")
+        );
+
+        final ResponseFieldsSnippet responseFieldsSnippet = responseFields(
+                numberFieldWithPath("id", "팀 ID"),
+                stringFieldWithPath("name", "팀 이름"),
+                stringFieldWithPath("description", "팀 설명"),
+                stringFieldWithPath("imageUrl", "이미지 url"),
+                numberFieldWithPath("attendanceRatio", "출석률")
+        );
+
+        when(teamQueryService.findTeamByTeamId(teamId)).thenReturn(teamResponse);
+
+        mockMvc.perform(get("/teams/{teamId}", teamId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("get-team", pathParameters, responseFieldsSnippet));
     }
 }

--- a/src/test/java/doore/team/application/TeamQueryServiceTest.java
+++ b/src/test/java/doore/team/application/TeamQueryServiceTest.java
@@ -1,19 +1,22 @@
 package doore.team.application;
 
+import static doore.member.MemberFixture.createMember;
 import static doore.member.MemberFixture.미나;
 import static doore.member.MemberFixture.아마란스;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+import static doore.team.TeamFixture.createTeam;
 import static doore.team.TeamFixture.team;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import doore.attendance.domain.Attendance;
+import doore.attendance.domain.repository.AttendanceRepository;
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
 import doore.member.domain.MemberTeam;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.MemberTeamRepository;
 import doore.member.exception.MemberException;
-import doore.team.TeamFixture;
 import doore.team.application.dto.response.TeamReferenceResponse;
 import doore.team.application.dto.response.TeamResponse;
 import doore.team.domain.Team;
@@ -34,12 +37,14 @@ class TeamQueryServiceTest extends IntegrationTest {
     private MemberTeamRepository memberTeamRepository;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private AttendanceRepository attendanceRepository;
 
-    private Long memberId;
+    private Member member;
 
     @BeforeEach
     void setUp() {
-        memberId = memberRepository.save(미나()).getId();
+        member = memberRepository.save(미나());
     }
 
     @Test
@@ -73,20 +78,25 @@ class TeamQueryServiceTest extends IntegrationTest {
         Long anotherMemberId = 2L;
         // 로그인 되어있는 아이디와 조회하려는 아이디가 다른 경우 실패 (주석은 확인 후 삭제할 예정입니다.)
         assertThatThrownBy(() -> {
-            teamQueryService.findMyTeams(memberId, anotherMemberId);
+            teamQueryService.findMyTeams(member.getId(), anotherMemberId);
         }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
     }
 
     @Test
     @DisplayName("[성공] 팀 상세 조회를 할 수 있다.")
     void findTeamByTeamId_팀_상세_조회를_할_수_있다_성공() {
-        Team team = TeamFixture.team();
-        teamRepository.save(team);
-        Long attendanceRatio = 50L;
+        Team team = createTeam();
+        Member anotherMember = createMember();
+        memberTeamRepository.save(MemberTeam.builder().teamId(team.getId()).member(member).isDeleted(false).build());
+        memberTeamRepository.save(
+                MemberTeam.builder().teamId(team.getId()).member(anotherMember).isDeleted(false).build());
+        attendanceRepository.save(Attendance.builder().memberId(anotherMember.getId()).build());
+
+        long attendanceRatio = 50L;
 
         TeamResponse expectTeamResponse = TeamResponse.of(team, attendanceRatio);
         TeamResponse actualTeamResponse = teamQueryService.findTeamByTeamId(team.getId());
 
-        assertThat(expectTeamResponse).isEqualTo(actualTeamResponse);
+        assertThat(actualTeamResponse).isEqualTo(expectTeamResponse);
     }
 }

--- a/src/test/java/doore/team/application/TeamQueryServiceTest.java
+++ b/src/test/java/doore/team/application/TeamQueryServiceTest.java
@@ -4,6 +4,7 @@ import static doore.member.MemberFixture.미나;
 import static doore.member.MemberFixture.아마란스;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.team.TeamFixture.team;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import doore.helper.IntegrationTest;
@@ -12,7 +13,9 @@ import doore.member.domain.MemberTeam;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.MemberTeamRepository;
 import doore.member.exception.MemberException;
+import doore.team.TeamFixture;
 import doore.team.application.dto.response.TeamReferenceResponse;
+import doore.team.application.dto.response.TeamResponse;
 import doore.team.domain.Team;
 import doore.team.domain.TeamRepository;
 import java.util.List;
@@ -72,5 +75,18 @@ class TeamQueryServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> {
             teamQueryService.findMyTeams(memberId, anotherMemberId);
         }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 상세 조회를 할 수 있다.")
+    void findTeamByTeamId_팀_상세_조회를_할_수_있다_성공() {
+        Team team = TeamFixture.team();
+        teamRepository.save(team);
+        Long attendanceRatio = 50L;
+
+        TeamResponse expectTeamResponse = TeamResponse.of(team, attendanceRatio);
+        TeamResponse actualTeamResponse = teamQueryService.findTeamByTeamId(team.getId());
+
+        assertThat(expectTeamResponse).isEqualTo(actualTeamResponse);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #127 

## 📝 작업 내용
- 팀 상세보기를 구현했습니다.
- 잔디와 팀원은 조회에서 제외해달라고 하셔서 넣지 않았습니다!

## 💬 리뷰 요구사항(선택)
- 확인해보시고 팀에 이것말고 더 조회되어야할 부분 알려주세요!
