### PR TITLE
Feature/#130 비회원 관련 권한 수정

### DIFF
--- a/src/main/java/doore/document/api/DocumentController.java
+++ b/src/main/java/doore/document/api/DocumentController.java
@@ -49,20 +49,19 @@ public class DocumentController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/{groupType}/{groupId}/documents") // 팀 학습자료 -> 비회원, 스터디 학습자료 -> 스터디 구성원
+    @GetMapping("/{groupType}/{groupId}/documents") // 비회원
     public ResponseEntity<Page<DocumentCondensedResponse>> getAllDocument(
             @PathVariable String groupType,
             @PathVariable Long groupId,
             @RequestParam(defaultValue = "0") @PositiveOrZero int page,
-            @RequestParam(defaultValue = "4") @PositiveOrZero int size,
-            @LoginMember Member member) {
+            @RequestParam(defaultValue = "4") @PositiveOrZero int size) {
         DocumentGroupType group = DocumentGroupType.value(groupType);
         Page<DocumentCondensedResponse> condensedDocuments =
-                documentQueryService.getAllDocument(group, groupId, PageRequest.of(page, size), member.getId());
+                documentQueryService.getAllDocument(group, groupId, PageRequest.of(page, size));
         return ResponseEntity.status(HttpStatus.OK).body(condensedDocuments);
     }
 
-    @GetMapping("/{documentId}") // 회원
+    @GetMapping("/{documentId}")  // 팀 학습자료 -> 비회원, 스터디 학습자료 -> 스터디 구성원
     public ResponseEntity<DocumentDetailResponse> getDocument(@PathVariable Long documentId, @LoginMember Member member) {
         DocumentDetailResponse response = documentQueryService.getDocument(documentId, member.getId());
         return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/main/java/doore/document/api/DocumentController.java
+++ b/src/main/java/doore/document/api/DocumentController.java
@@ -49,7 +49,7 @@ public class DocumentController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/{groupType}/{groupId}/documents") // 회원
+    @GetMapping("/{groupType}/{groupId}/documents") // 팀 학습자료 -> 회원, 스터디 학습자료 -> 스터디 구성원
     public ResponseEntity<Page<DocumentCondensedResponse>> getAllDocument(
             @PathVariable String groupType,
             @PathVariable Long groupId,

--- a/src/main/java/doore/document/api/DocumentController.java
+++ b/src/main/java/doore/document/api/DocumentController.java
@@ -49,7 +49,7 @@ public class DocumentController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/{groupType}/{groupId}/documents") // 팀 학습자료 -> 회원, 스터디 학습자료 -> 스터디 구성원
+    @GetMapping("/{groupType}/{groupId}/documents") // 팀 학습자료 -> 비회원, 스터디 학습자료 -> 스터디 구성원
     public ResponseEntity<Page<DocumentCondensedResponse>> getAllDocument(
             @PathVariable String groupType,
             @PathVariable Long groupId,

--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -1,20 +1,26 @@
 package doore.document.application;
 
+import static doore.document.domain.DocumentGroupType.STUDY;
 import static doore.document.exception.DocumentExceptionType.NOT_FOUND_DOCUMENT;
+import static doore.member.domain.StudyRoleType.ROLE_스터디원;
+import static doore.member.domain.StudyRoleType.ROLE_스터디장;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
+import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 
 import doore.document.application.dto.response.DocumentCondensedResponse;
 import doore.document.application.dto.response.DocumentDetailResponse;
 import doore.document.application.dto.response.FileResponse;
 import doore.document.domain.Document;
-import doore.document.exception.DocumentException;
-import java.util.ArrayList;
 import doore.document.domain.DocumentGroupType;
 import doore.document.domain.File;
 import doore.document.domain.repository.DocumentRepository;
+import doore.document.exception.DocumentException;
+import doore.member.domain.StudyRole;
 import doore.member.domain.repository.MemberRepository;
+import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.exception.MemberException;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,10 +35,13 @@ public class DocumentQueryService {
 
     private final DocumentRepository documentRepository;
     private final MemberRepository memberRepository;
+    private final StudyRoleRepository studyRoleRepository;
 
     public Page<DocumentCondensedResponse> getAllDocument(
             DocumentGroupType groupType, Long groupId, Pageable pageable, Long memberId) {
-        validateExistMember(memberId);
+        if (groupType == STUDY) {
+            validateMemberRoleForStudy(memberId);
+        }
         return documentRepository.findAllByGroupTypeAndGroupId(groupType, groupId, pageable)
                 .map(this::toDocumentCondensedResponse);
     }
@@ -76,5 +85,13 @@ public class DocumentQueryService {
 
     private void validateExistMember(Long memberId) {
         memberRepository.findById(memberId).orElseThrow(() -> new MemberException(UNAUTHORIZED));
+    }
+
+    private void validateMemberRoleForStudy(Long memberId) {
+        StudyRole studyRole = studyRoleRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
+        if (!(studyRole.getStudyRoleType() == ROLE_스터디장 || studyRole.getStudyRoleType() == ROLE_스터디원)) {
+            throw new MemberException(UNAUTHORIZED);
+        }
     }
 }

--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -38,10 +38,8 @@ public class DocumentQueryService {
     private final StudyRoleRepository studyRoleRepository;
 
     public Page<DocumentCondensedResponse> getAllDocument(
-            DocumentGroupType groupType, Long groupId, Pageable pageable, Long memberId) {
-        if (groupType == STUDY) {
-            validateMemberRoleForStudy(memberId);
-        }
+            DocumentGroupType groupType, Long groupId, Pageable pageable) {
+
         return documentRepository.findAllByGroupTypeAndGroupId(groupType, groupId, pageable)
                 .map(this::toDocumentCondensedResponse);
     }
@@ -57,6 +55,10 @@ public class DocumentQueryService {
         validateExistMember(memberId);
         Document document = documentRepository.findById(documentId)
                 .orElseThrow(() -> new DocumentException(NOT_FOUND_DOCUMENT));
+        DocumentGroupType documentGroupType = document.getGroupType();
+        if (documentGroupType == STUDY) {
+            validateMemberRoleForStudy(memberId);
+        }
         return toDocumentDetailResponse(document);
     }
 

--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -52,7 +52,6 @@ public class DocumentQueryService {
     }
 
     public DocumentDetailResponse getDocument(Long documentId, Long memberId) {
-        validateExistMember(memberId);
         Document document = documentRepository.findById(documentId)
                 .orElseThrow(() -> new DocumentException(NOT_FOUND_DOCUMENT));
         DocumentGroupType documentGroupType = document.getGroupType();

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -46,9 +46,9 @@ public class StudyController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @GetMapping("/studies/{studyId}")
-    public ResponseEntity<StudyResponse> getStudy(@PathVariable Long studyId, @LoginMember Member member) {
-        StudyResponse studyDetailResponse = studyQueryService.findStudyById(studyId, member.getId());
+    @GetMapping("/studies/{studyId}") // 비회원
+    public ResponseEntity<StudyResponse> getStudy(@PathVariable Long studyId) {
+        StudyResponse studyDetailResponse = studyQueryService.findStudyById(studyId);
         return ResponseEntity.ok(studyDetailResponse);
     }
 

--- a/src/main/java/doore/study/application/StudyQueryService.java
+++ b/src/main/java/doore/study/application/StudyQueryService.java
@@ -47,9 +47,8 @@ public class StudyQueryService {
     private final MemberRepository memberRepository;
     private final StudyDao studyDao;
 
-    public StudyResponse findStudyById(Long studyId, Long memberId) {
+    public StudyResponse findStudyById(Long studyId) {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
-        validateExistStudyLeaderAndParticipant(memberId);
 
         final Team team = teamRepository.findById(study.getTeamId())
                 .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));

--- a/src/test/java/doore/document/application/DocumentQueryServiceTest.java
+++ b/src/test/java/doore/document/application/DocumentQueryServiceTest.java
@@ -4,6 +4,7 @@ import static doore.document.domain.DocumentGroupType.TEAM;
 import static doore.document.domain.DocumentType.URL;
 import static doore.member.MemberFixture.미나;
 import static doore.member.MemberFixture.아마란스;
+import static doore.member.MemberFixture.짱구;
 import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.team.TeamFixture.team;
@@ -56,6 +57,7 @@ public class DocumentQueryServiceTest extends IntegrationTest {
     private Document anotherDocument;
     private Member member;
     private Member anotherMember;
+    private Member notMember;
     private StudyRole studyRole;
     private Team team;
 
@@ -65,6 +67,7 @@ public class DocumentQueryServiceTest extends IntegrationTest {
         study = studyRepository.save(algorithmStudy());
         member = memberRepository.save(아마란스());
         anotherMember = memberRepository.save(미나());
+        notMember = 짱구();
         studyRole = studyRoleRepository.save(StudyRole.builder()
                 .studyRoleType(ROLE_스터디원)
                 .studyId(study.getId())
@@ -108,7 +111,7 @@ public class DocumentQueryServiceTest extends IntegrationTest {
         //given&when
         Page<DocumentCondensedResponse> responses =
                 documentQueryService.getAllDocument(TEAM, team.getId(), PageRequest.of(0, 4),
-                        anotherMember.getId());
+                        notMember.getId());
 
         //then
         assertAll(

--- a/src/test/java/doore/document/application/DocumentQueryServiceTest.java
+++ b/src/test/java/doore/document/application/DocumentQueryServiceTest.java
@@ -108,7 +108,7 @@ public class DocumentQueryServiceTest extends IntegrationTest {
     @DisplayName("[성공] 정상적으로 팀 학습자료 상세를 조회할 수 있다.")
     public void getDocument_정상적으로_팀_학습자료_상세를_조회할_수_있다_성공() {
         //given&when
-        DocumentDetailResponse response = documentQueryService.getDocument(anotherDocument.getId(), anotherMember.getId());
+        DocumentDetailResponse response = documentQueryService.getDocument(anotherDocument.getId(), notMember.getId());
 
         //then
         assertAll(

--- a/src/test/java/doore/document/application/DocumentQueryServiceTest.java
+++ b/src/test/java/doore/document/application/DocumentQueryServiceTest.java
@@ -1,7 +1,12 @@
 package doore.document.application;
 
+import static doore.document.domain.DocumentGroupType.TEAM;
+import static doore.document.domain.DocumentType.URL;
+import static doore.member.MemberFixture.미나;
 import static doore.member.MemberFixture.아마란스;
-import static doore.study.StudyFixture.createStudy;
+import static doore.member.domain.StudyRoleType.ROLE_스터디원;
+import static doore.study.StudyFixture.algorithmStudy;
+import static doore.team.TeamFixture.team;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,13 +16,16 @@ import doore.document.application.dto.response.DocumentCondensedResponse;
 import doore.document.application.dto.response.DocumentDetailResponse;
 import doore.document.domain.Document;
 import doore.document.domain.DocumentGroupType;
-import doore.document.domain.DocumentType;
 import doore.document.domain.repository.DocumentRepository;
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
+import doore.member.domain.StudyRole;
 import doore.member.domain.repository.MemberRepository;
+import doore.member.domain.repository.StudyRoleRepository;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
+import doore.team.domain.Team;
+import doore.team.domain.TeamRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,26 +46,47 @@ public class DocumentQueryServiceTest extends IntegrationTest {
     private DocumentRepository documentRepository;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private StudyRoleRepository studyRoleRepository;
+    @Autowired
+    private TeamRepository teamRepository;
 
     private Study study;
     private Document document;
+    private Document anotherDocument;
     private Member member;
+    private Member anotherMember;
+    private StudyRole studyRole;
+    private Team team;
 
     @BeforeEach
     void setUp() {
-        study = createStudy();
+        team = teamRepository.save(team());
+        study = studyRepository.save(algorithmStudy());
         member = memberRepository.save(아마란스());
+        anotherMember = memberRepository.save(미나());
+        studyRole = studyRoleRepository.save(StudyRole.builder()
+                .studyRoleType(ROLE_스터디원)
+                .studyId(study.getId())
+                .memberId(member.getId())
+                .build());
         document = new DocumentFixture()
                 .groupType(DocumentGroupType.STUDY)
                 .groupId(study.getId())
-                .type(DocumentType.URL)
+                .type(URL)
+                .uploaderId(member.getId())
+                .buildDocument();
+        anotherDocument = new DocumentFixture()
+                .groupType(TEAM)
+                .groupId(team.getId())
+                .type(URL)
                 .uploaderId(member.getId())
                 .buildDocument();
     }
 
     @Test
-    @DisplayName("[성공] 정상적으로 학습자료 목록을 조회할 수 있다")
-    public void getAllDocumentList_정상적으로_학습자료_목록을_조회할_수_있다_성공() {
+    @DisplayName("[성공] 정상적으로 스터디 학습자료 목록을 조회할 수 있다")
+    public void getAllDocumentList_정상적으로_스터디_학습자료_목록을_조회할_수_있다_성공() {
         //given&when
         Page<DocumentCondensedResponse> responses =
                 documentQueryService.getAllDocument(DocumentGroupType.STUDY, study.getId(), PageRequest.of(0, 4),
@@ -70,6 +99,24 @@ public class DocumentQueryServiceTest extends IntegrationTest {
                 () -> assertEquals(responses.getContent().get(0).description(), document.getDescription()),
                 () -> assertEquals(responses.getContent().get(0).date(), document.getCreatedAt().toLocalDate()),
                 () -> assertEquals(responses.getContent().get(0).uploaderId(), document.getUploaderId())
+        );
+    }
+
+    @Test
+    @DisplayName("[성공] 정상적으로 팀 학습자료 목록을 조회할 수 있다")
+    public void getAllDocumentList_정상적으로_팀_학습자료_목록을_조회할_수_있다_성공() {
+        //given&when
+        Page<DocumentCondensedResponse> responses =
+                documentQueryService.getAllDocument(TEAM, team.getId(), PageRequest.of(0, 4),
+                        anotherMember.getId());
+
+        //then
+        assertAll(
+                () -> assertThat(responses.getSize()).isNotZero(),
+                () -> assertEquals(responses.getContent().get(0).title(), anotherDocument.getName()),
+                () -> assertEquals(responses.getContent().get(0).description(), anotherDocument.getDescription()),
+                () -> assertEquals(responses.getContent().get(0).date(), anotherDocument.getCreatedAt().toLocalDate()),
+                () -> assertEquals(responses.getContent().get(0).uploaderId(), anotherDocument.getUploaderId())
         );
     }
 

--- a/src/test/java/doore/document/application/DocumentQueryServiceTest.java
+++ b/src/test/java/doore/document/application/DocumentQueryServiceTest.java
@@ -88,30 +88,11 @@ public class DocumentQueryServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[성공] 정상적으로 스터디 학습자료 목록을 조회할 수 있다")
-    public void getAllDocumentList_정상적으로_스터디_학습자료_목록을_조회할_수_있다_성공() {
+    @DisplayName("[성공] 비회원이_정상적으로 팀 학습자료 목록을 조회할 수 있다")
+    public void getAllDocumentList_비회원이_정상적으로_팀_학습자료_목록을_조회할_수_있다_성공() {
         //given&when
         Page<DocumentCondensedResponse> responses =
-                documentQueryService.getAllDocument(DocumentGroupType.STUDY, study.getId(), PageRequest.of(0, 4),
-                        member.getId());
-
-        //then
-        assertAll(
-                () -> assertThat(responses.getSize()).isNotZero(),
-                () -> assertEquals(responses.getContent().get(0).title(), document.getName()),
-                () -> assertEquals(responses.getContent().get(0).description(), document.getDescription()),
-                () -> assertEquals(responses.getContent().get(0).date(), document.getCreatedAt().toLocalDate()),
-                () -> assertEquals(responses.getContent().get(0).uploaderId(), document.getUploaderId())
-        );
-    }
-
-    @Test
-    @DisplayName("[성공] 정상적으로 팀 학습자료 목록을 조회할 수 있다")
-    public void getAllDocumentList_정상적으로_팀_학습자료_목록을_조회할_수_있다_성공() {
-        //given&when
-        Page<DocumentCondensedResponse> responses =
-                documentQueryService.getAllDocument(TEAM, team.getId(), PageRequest.of(0, 4),
-                        notMember.getId());
+                documentQueryService.getAllDocument(TEAM, team.getId(), PageRequest.of(0, 4));
 
         //then
         assertAll(
@@ -124,10 +105,26 @@ public class DocumentQueryServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[성공] 정상적으로 학습자료 상세를 조회할 수 있다.")
-    public void getDocument_정상적으로_학습자료_상세를_조회할_수_있다_성공() {
+    @DisplayName("[성공] 정상적으로 팀 학습자료 상세를 조회할 수 있다.")
+    public void getDocument_정상적으로_팀_학습자료_상세를_조회할_수_있다_성공() {
+        //given&when
+        DocumentDetailResponse response = documentQueryService.getDocument(anotherDocument.getId(), anotherMember.getId());
+
+        //then
+        assertAll(
+                () -> assertEquals(response.title(), anotherDocument.getName()),
+                () -> assertEquals(response.description(), anotherDocument.getDescription()),
+                () -> assertEquals(response.date(), anotherDocument.getCreatedAt().toLocalDate()),
+                () -> assertEquals(response.accessType(), anotherDocument.getAccessType())
+        );
+    }
+
+    @Test
+    @DisplayName("[성공] 정상적으로 스터디 학습자료 상세를 조회할 수 있다")
+    public void getDocument_정상적으로_스터디_학습자료_상세를_조회할_수_있다_성공() {
         //given&when
         DocumentDetailResponse response = documentQueryService.getDocument(document.getId(), member.getId());
+
         //then
         assertAll(
                 () -> assertEquals(response.title(), document.getName()),

--- a/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
@@ -105,7 +105,7 @@ public class DocumentDocsTest extends RestDocsTest {
         Page<DocumentCondensedResponse> documentCondensedResponses = new PageImpl<>(
                 List.of(documentCondensedResponse, otherDocumentCondensedResponse), PageRequest.of(0,4),2);
         //when
-        when(documentQueryService.getAllDocument(any(), any(), any(PageRequest.class), any()))
+        when(documentQueryService.getAllDocument(any(), any(), any(PageRequest.class)))
                 .thenReturn(documentCondensedResponses);
 
         //then

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -73,7 +73,7 @@ public class StudyApiDocsTest extends RestDocsTest {
     public void 스터디_정보를_조회한다() throws Exception {
         StudyResponse studyResponse = getStudyResponse();
 
-        when(studyQueryService.findStudyById(any(), any())).thenReturn(studyResponse);
+        when(studyQueryService.findStudyById(any())).thenReturn(studyResponse);
 
         mockMvc.perform(RestDocumentationRequestBuilders.get("/studies/{studyId}", 1))
                 .andExpect(status().isOk())

--- a/src/test/java/doore/study/application/StudyQueryServiceTest.java
+++ b/src/test/java/doore/study/application/StudyQueryServiceTest.java
@@ -81,14 +81,14 @@ public class StudyQueryServiceTest extends IntegrationTest {
         void findStudyById_정상적으로_스터디를_조회할_수_있다_성공() throws Exception {
             Study study = createStudy();
             studyRepository.save(study);
-            assertEquals(study.getId(), studyQueryService.findStudyById(study.getId(), memberId).id());
+            assertEquals(study.getId(), studyQueryService.findStudyById(study.getId()).id());
         }
 
         @Test
         @DisplayName("[실패] 존재하지 않는 스터디를 조회할 수 없다.")
         void findStudyById_존재하지_않는_스터디를_조회할_수_없다_실패() throws Exception {
             Long notExistingStudyId = 0L;
-            assertThatThrownBy(() -> studyQueryService.findStudyById(notExistingStudyId, memberId))
+            assertThatThrownBy(() -> studyQueryService.findStudyById(notExistingStudyId))
                     .isInstanceOf(StudyException.class)
                     .hasMessage(NOT_FOUND_STUDY.errorMessage());
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #130 

## 📝 작업 내용

- 비회원 관련 권한을 수정하였습니다.
    - 비회원은 팀 페이지 + 스터디 페이지 + 팀 학습자료까지 조회가 가능합니다.
    - 스터디 구성원만이 스터디 학습자료 조회가 가능합니다.

## 💬 리뷰 요구사항(선택)

- 팀 페이지 권한 수정은 팀 상세보기 pr이 머지되면 pull 받아서 합쳐두겠습니다! (이미 팀 상세보기는 비회원 권한으로 작성되어있음)
