### PR TITLE
Feature/#136 텃밭 테스트 수정

### DIFF
--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -78,13 +78,13 @@ public class CurriculumItemCommandService {
         deleteGarden(participantCurriculumItem);
     }
 
-    public void createGarden(ParticipantCurriculumItem participantCurriculumItem) {
+    private void createGarden(ParticipantCurriculumItem participantCurriculumItem) {
         Garden garden = GardenType.getSupplierOf(participantCurriculumItem.getClass().getSimpleName())
                 .of(participantCurriculumItem);
         gardenRepository.save(garden);
     }
 
-    public void deleteGarden(ParticipantCurriculumItem participantCurriculumItem) {
+    private void deleteGarden(ParticipantCurriculumItem participantCurriculumItem) {
         Long contributionId = participantCurriculumItem.getId();
         GardenType gardenType = GardenType.getGardenTypeOf(participantCurriculumItem.getClass().getSimpleName());
         gardenRepository.deleteByContributionIdAndType(contributionId, gardenType);

--- a/src/main/java/doore/study/application/dto/response/StudyResponse.java
+++ b/src/main/java/doore/study/application/dto/response/StudyResponse.java
@@ -10,6 +10,7 @@ import doore.team.domain.Team;
 import java.time.LocalDate;
 import lombok.Builder;
 
+@Builder
 public record StudyResponse(
         Long id,
         String name,
@@ -22,19 +23,6 @@ public record StudyResponse(
         TeamReferenceResponse teamReference,
         CropReferenceResponse cropReference
 ) {
-    @Builder
-    public StudyResponse(Long id, String name, String description, LocalDate startDate, LocalDate endDate,
-                         StudyStatus status, TeamReferenceResponse teamReference, CropReferenceResponse cropReference) {
-        this.id = id;
-        this.name = name;
-        this.description = description;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.status = status;
-        this.teamReference = teamReference;
-        this.cropReference = cropReference;
-    }
-
     public static StudyResponse of(final Study study, final Team team, final Crop crop) {
         return StudyResponse.builder()
                 .id(study.getId())

--- a/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
+++ b/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
@@ -245,21 +245,26 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 커리큘럼 타입의 텃밭을 정상적으로 삭제할 수 있다. ")
     public void deleteGarden_커리큘럼_타입의_텃밭을_정상적으로_삭제할_수_있다_성공() throws Exception {
-//            //given
-//            CurriculumItem curriculumItem = curriculumItemRepository.save(curriculumItem());
-//            ParticipantCurriculumItem participantCurriculumItem = ParticipantCurriculumItem.builder()
-//                    .participantId(1L)
-//                    .curriculumItem(curriculumItem)
-//                    .build();
-//            participantCurriculumItemRepository.save(participantCurriculumItem);
-//
-//            curriculumItemCommandService.createGarden(participantCurriculumItem);
-//            assertEquals(1, gardenRepository.findAll().size());
-//
-//            //when
-//            curriculumItemCommandService.deleteGarden(participantCurriculumItem);
-//
-//            //then
-//            assertEquals(0, gardenRepository.findAll().size());
+        Member member = memberRepository.save(보름());
+        Participant participant = participantRepository.save(Participant.builder()
+                .member(member)
+                .studyId(study.getId())
+                .build());
+
+        curriculumItemCommandService.manageCurriculum(request, study.getId(), memberId);
+        CurriculumItem curriculumItem = curriculumItemRepository.findById(4L).orElseThrow();
+        curriculumItemCommandService.checkCurriculum(curriculumItem.getId(), participant.getId(), memberId);
+
+        ParticipantCurriculumItem beforeParticipantCurriculumItem = participantCurriculumItemRepository.findByCurriculumItemIdAndParticipantId(
+                curriculumItem.getId(), participant.getId()).orElseThrow();
+        assertThat(beforeParticipantCurriculumItem.getIsChecked()).isEqualTo(true);
+        assertThat(gardenRepository.findAll().size()).isEqualTo(1);
+
+        curriculumItemCommandService.checkCurriculum(curriculumItem.getId(), participant.getId(), memberId);
+        ParticipantCurriculumItem afterParticipantCurriculumItem = participantCurriculumItemRepository.findByCurriculumItemIdAndParticipantId(
+                curriculumItem.getId(), participant.getId()).orElseThrow();
+
+        assertThat(afterParticipantCurriculumItem.getIsChecked()).isEqualTo(false);
+        assertThat(gardenRepository.findAll().size()).isEqualTo(0);
     }
 }

--- a/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
+++ b/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
@@ -1,12 +1,11 @@
 package doore.study.application;
 
+import static doore.garden.domain.GardenType.STUDY_CURRICULUM_COMPLETION;
 import static doore.member.MemberFixture.미나;
 import static doore.member.MemberFixture.아마란스;
 import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
-import static doore.garden.domain.GardenType.STUDY_CURRICULUM_COMPLETION;
 import static doore.study.CurriculumItemFixture.curriculumItem;
-
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_PARTICIPANT;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
@@ -149,51 +148,6 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
         assertThat(result.getIsChecked()).isEqualTo(false);
     }
 
-    @Nested
-    @DisplayName("커리큘럼 체크 여부에 따라 정상적으로 텃밭을 생성 혹은 삭제한다.")
-    class CurriculumGardenTest {
-        @Test
-        @DisplayName("[성공] 커리큘럼 타입의 텃밭을 정상적으로 생성할 수 있다. ")
-        public void createGarden_커리큘럼_타입의_텃밭을_정상적으로_생성할_수_있다_성공() throws Exception {
-            //given
-            CurriculumItem curriculumItem = curriculumItemRepository.save(curriculumItem());
-            ParticipantCurriculumItem participantCurriculumItem = ParticipantCurriculumItem.builder()
-                    .participantId(1L)
-                    .curriculumItem(curriculumItem)
-                    .build();
-            participantCurriculumItemRepository.save(participantCurriculumItem);
-
-            //when
-            curriculumItemCommandService.createGarden(participantCurriculumItem);
-
-            //then
-            Garden garden = gardenRepository.findAll().get(0);
-            assertEquals(garden.getContributionId(), participantCurriculumItem.getId());
-            assertEquals(garden.getType(), STUDY_CURRICULUM_COMPLETION);
-        }
-
-        @Test
-        @DisplayName("[성공] 커리큘럼 타입의 텃밭을 정상적으로 삭제할 수 있다. ")
-        public void deleteGarden_커리큘럼_타입의_텃밭을_정상적으로_삭제할_수_있다_성공() throws Exception {
-            //given
-            CurriculumItem curriculumItem = curriculumItemRepository.save(curriculumItem());
-            ParticipantCurriculumItem participantCurriculumItem = ParticipantCurriculumItem.builder()
-                    .participantId(1L)
-                    .curriculumItem(curriculumItem)
-                    .build();
-            participantCurriculumItemRepository.save(participantCurriculumItem);
-
-            curriculumItemCommandService.createGarden(participantCurriculumItem);
-            assertEquals(1, gardenRepository.findAll().size());
-
-            //when
-            curriculumItemCommandService.deleteGarden(participantCurriculumItem);
-
-            //then
-            assertEquals(0, gardenRepository.findAll().size());
-        }
-    }
-
     @Test
     @DisplayName("[성공] 아이디가 없으면 커리큘럼을 생성한다.")
     public void createCurriculum_아이디가_없으면_커리큘럼을_생성한다() throws Exception {
@@ -266,5 +220,50 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> curriculumItemCommandService.manageCurriculum(request, study.getId(), member.getId()))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(UNAUTHORIZED.errorMessage());
+    }
+
+    @Nested
+    @DisplayName("커리큘럼 체크 여부에 따라 정상적으로 텃밭을 생성 혹은 삭제한다.")
+    class CurriculumGardenTest {
+        @Test
+        @DisplayName("[성공] 커리큘럼 타입의 텃밭을 정상적으로 생성할 수 있다. ")
+        public void createGarden_커리큘럼_타입의_텃밭을_정상적으로_생성할_수_있다_성공() throws Exception {
+            //given
+            CurriculumItem curriculumItem = curriculumItemRepository.save(curriculumItem());
+            ParticipantCurriculumItem participantCurriculumItem = ParticipantCurriculumItem.builder()
+                    .participantId(1L)
+                    .curriculumItem(curriculumItem)
+                    .build();
+            participantCurriculumItemRepository.save(participantCurriculumItem);
+
+            //when
+            curriculumItemCommandService.createGarden(participantCurriculumItem);
+
+            //then
+            Garden garden = gardenRepository.findAll().get(0);
+            assertEquals(garden.getContributionId(), participantCurriculumItem.getId());
+            assertEquals(garden.getType(), STUDY_CURRICULUM_COMPLETION);
+        }
+
+        @Test
+        @DisplayName("[성공] 커리큘럼 타입의 텃밭을 정상적으로 삭제할 수 있다. ")
+        public void deleteGarden_커리큘럼_타입의_텃밭을_정상적으로_삭제할_수_있다_성공() throws Exception {
+            //given
+            CurriculumItem curriculumItem = curriculumItemRepository.save(curriculumItem());
+            ParticipantCurriculumItem participantCurriculumItem = ParticipantCurriculumItem.builder()
+                    .participantId(1L)
+                    .curriculumItem(curriculumItem)
+                    .build();
+            participantCurriculumItemRepository.save(participantCurriculumItem);
+
+            curriculumItemCommandService.createGarden(participantCurriculumItem);
+            assertEquals(1, gardenRepository.findAll().size());
+
+            //when
+            curriculumItemCommandService.deleteGarden(participantCurriculumItem);
+
+            //then
+            assertEquals(0, gardenRepository.findAll().size());
+        }
     }
 }

--- a/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
+++ b/src/test/java/doore/study/application/CurriculumItemCommandServiceTest.java
@@ -2,10 +2,10 @@ package doore.study.application;
 
 import static doore.garden.domain.GardenType.STUDY_CURRICULUM_COMPLETION;
 import static doore.member.MemberFixture.미나;
+import static doore.member.MemberFixture.보름;
 import static doore.member.MemberFixture.아마란스;
 import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
-import static doore.study.CurriculumItemFixture.curriculumItem;
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_PARTICIPANT;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -222,48 +221,45 @@ public class CurriculumItemCommandServiceTest extends IntegrationTest {
                 .hasMessage(UNAUTHORIZED.errorMessage());
     }
 
-    @Nested
-    @DisplayName("커리큘럼 체크 여부에 따라 정상적으로 텃밭을 생성 혹은 삭제한다.")
-    class CurriculumGardenTest {
-        @Test
-        @DisplayName("[성공] 커리큘럼 타입의 텃밭을 정상적으로 생성할 수 있다. ")
-        public void createGarden_커리큘럼_타입의_텃밭을_정상적으로_생성할_수_있다_성공() throws Exception {
-            //given
-            CurriculumItem curriculumItem = curriculumItemRepository.save(curriculumItem());
-            ParticipantCurriculumItem participantCurriculumItem = ParticipantCurriculumItem.builder()
-                    .participantId(1L)
-                    .curriculumItem(curriculumItem)
-                    .build();
-            participantCurriculumItemRepository.save(participantCurriculumItem);
 
-            //when
-            curriculumItemCommandService.createGarden(participantCurriculumItem);
+    @Test
+    @DisplayName("[성공] 커리큘럼 타입의 텃밭을 정상적으로 생성할 수 있다. ")
+    public void createGarden_커리큘럼_타입의_텃밭을_정상적으로_생성할_수_있다_성공() throws Exception {
+        Member member = memberRepository.save(보름());
+        Participant participant = participantRepository.save(Participant.builder()
+                .member(member)
+                .studyId(study.getId())
+                .build());
 
-            //then
-            Garden garden = gardenRepository.findAll().get(0);
-            assertEquals(garden.getContributionId(), participantCurriculumItem.getId());
-            assertEquals(garden.getType(), STUDY_CURRICULUM_COMPLETION);
-        }
+        curriculumItemCommandService.manageCurriculum(request, study.getId(), memberId);
+        CurriculumItem curriculumItem = curriculumItemRepository.findById(4L).orElseThrow();
+        curriculumItemCommandService.checkCurriculum(curriculumItem.getId(), participant.getId(), memberId);
+        ParticipantCurriculumItem participantCurriculumItem = participantCurriculumItemRepository.findByCurriculumItemIdAndParticipantId(
+                curriculumItem.getId(), participant.getId()).orElseThrow();
+        Garden garden = gardenRepository.findAll().get(0);
 
-        @Test
-        @DisplayName("[성공] 커리큘럼 타입의 텃밭을 정상적으로 삭제할 수 있다. ")
-        public void deleteGarden_커리큘럼_타입의_텃밭을_정상적으로_삭제할_수_있다_성공() throws Exception {
-            //given
-            CurriculumItem curriculumItem = curriculumItemRepository.save(curriculumItem());
-            ParticipantCurriculumItem participantCurriculumItem = ParticipantCurriculumItem.builder()
-                    .participantId(1L)
-                    .curriculumItem(curriculumItem)
-                    .build();
-            participantCurriculumItemRepository.save(participantCurriculumItem);
+        assertThat(garden.getContributionId()).isEqualTo(participantCurriculumItem.getId());
+        assertEquals(garden.getType(), STUDY_CURRICULUM_COMPLETION);
+    }
 
-            curriculumItemCommandService.createGarden(participantCurriculumItem);
-            assertEquals(1, gardenRepository.findAll().size());
-
-            //when
-            curriculumItemCommandService.deleteGarden(participantCurriculumItem);
-
-            //then
-            assertEquals(0, gardenRepository.findAll().size());
-        }
+    @Test
+    @DisplayName("[성공] 커리큘럼 타입의 텃밭을 정상적으로 삭제할 수 있다. ")
+    public void deleteGarden_커리큘럼_타입의_텃밭을_정상적으로_삭제할_수_있다_성공() throws Exception {
+//            //given
+//            CurriculumItem curriculumItem = curriculumItemRepository.save(curriculumItem());
+//            ParticipantCurriculumItem participantCurriculumItem = ParticipantCurriculumItem.builder()
+//                    .participantId(1L)
+//                    .curriculumItem(curriculumItem)
+//                    .build();
+//            participantCurriculumItemRepository.save(participantCurriculumItem);
+//
+//            curriculumItemCommandService.createGarden(participantCurriculumItem);
+//            assertEquals(1, gardenRepository.findAll().size());
+//
+//            //when
+//            curriculumItemCommandService.deleteGarden(participantCurriculumItem);
+//
+//            //then
+//            assertEquals(0, gardenRepository.findAll().size());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #136 

## 📝 작업 내용

- 텃밭 테스트를 수정했습니다.
- `Builder` 수정은.. 따로 이슈파서 처리하기에는 사소한 이슈라서 함께 처리했습니당
- `deleteGardenTest`는 커리큘럼`check`가 `true`에서 `false`가 되었을때의 변화를 보여주면 좋을 것 같아서 좀 길더라도 `beforeParticipantCurriculumItem`을 추가해서 상태를 확인하는 코드를 추가하였습니다!

