### PR TITLE
Feature/#99 팀 랭킹 구현

### DIFF
--- a/src/docs/asciidoc/team.adoc
+++ b/src/docs/asciidoc/team.adoc
@@ -125,3 +125,17 @@ include::{snippets}/get-team/http-response.adoc[]
 
 .Response Body's Fields
 include::{snippets}/get-team/response-fields.adoc[]
+
+== `GET`: 팀 목록(랭킹) 조회
+
+NOTE: 이번주(월요일부터 시작)의 기여도 총합을 기준으로 내림차순 나열됩니다.
+
+
+.HTTP Request
+include::{snippets}/get-team-week-rank/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-team-week-rank/http-response.adoc[]
+
+.Response Body's Fields
+include::{snippets}/get-team-week-rank/response-fields.adoc[]

--- a/src/main/java/doore/garden/application/GardenQueryService.java
+++ b/src/main/java/doore/garden/application/GardenQueryService.java
@@ -3,6 +3,8 @@ package doore.garden.application;
 import doore.garden.application.dto.response.DayGardenResponse;
 import doore.garden.domain.Garden;
 import doore.garden.domain.repository.GardenRepository;
+import doore.team.domain.Team;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,16 @@ public class GardenQueryService {
 
     public List<DayGardenResponse> getAllGarden(Long teamId) {
         List<Garden> gardens = gardenRepository.findAllOfThisYearByTeamIdOrderByContributedDateAsc(teamId);
+        return calculateContributes(gardens);
+    }
+
+    public DayGardenResponse getTodayGarden(Long teamId) {
+        List<Garden> gardens = gardenRepository.findTodayGardenByTeamId(teamId);
+        return calculateContributes(gardens).get(0);
+    }
+
+    public List<DayGardenResponse> getThisWeekGarden(Long teamId) {
+        List<Garden> gardens = gardenRepository.findThisWeekGardenByTeamId(teamId);
         return calculateContributes(gardens);
     }
 

--- a/src/main/java/doore/garden/domain/repository/GardenRepository.java
+++ b/src/main/java/doore/garden/domain/repository/GardenRepository.java
@@ -10,4 +10,10 @@ public interface GardenRepository extends JpaRepository<Garden,Long> {
     void deleteByContributionIdAndType(Long contributionId, GardenType gardenType);
     @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND YEAR(g.contributedDate) = YEAR(CURRENT_DATE) ORDER BY g.contributedDate ASC")
     List<Garden> findAllOfThisYearByTeamIdOrderByContributedDateAsc(Long teamId); //올해의 데이터만 가져온다.
+
+    @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND g.contributedDate = CURRENT_DATE")
+    List<Garden> findTodayGardenByTeamId(Long teamId); //오늘의 데이터만 가져온다.
+
+    @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND WEEK(g.contributedDate, 1) = WEEK(CURRENT_DATE, 1) ORDER BY g.contributedDate ASC")
+    List<Garden> findThisWeekGardenByTeamId(Long teamId); //이번주의 데이터만 가져온다.(월~일)
 }

--- a/src/main/java/doore/team/api/TeamController.java
+++ b/src/main/java/doore/team/api/TeamController.java
@@ -9,6 +9,7 @@ import doore.team.application.dto.request.TeamInviteCodeRequest;
 import doore.team.application.dto.request.TeamUpdateRequest;
 import doore.team.application.dto.response.MyTeamsAndStudiesResponse;
 import doore.team.application.dto.response.TeamInviteCodeResponse;
+import doore.team.application.dto.response.TeamRankResponse;
 import doore.team.application.dto.response.TeamReferenceResponse;
 import doore.team.application.dto.response.TeamResponse;
 import jakarta.validation.Valid;
@@ -109,5 +110,12 @@ public class TeamController {
     @GetMapping("/{teamId}") // 비회원
     public ResponseEntity<TeamResponse> getTeam(@PathVariable final Long teamId) {
         return ResponseEntity.ok(teamQueryService.findTeamByTeamId(teamId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TeamRankResponse>> getTeams(
+    ) { //비회원
+        final List<TeamRankResponse> teamRankResponses = teamQueryService.getTeamRanks();
+        return ResponseEntity.ok(teamRankResponses);
     }
 }

--- a/src/main/java/doore/team/application/dto/response/TeamRankResponse.java
+++ b/src/main/java/doore/team/application/dto/response/TeamRankResponse.java
@@ -1,0 +1,7 @@
+package doore.team.application.dto.response;
+
+public record TeamRankResponse(
+        int point,
+        TeamReferenceResponse teamReferenceResponse
+) {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #99

## 📝 작업 내용

팀 랭킹 구현을 구현했습니다. 
일주일(월~일)간의 팀의 텃밭 내역을 총합하여 총합 기여도가 가장 높은 순으로 팀이 나열됩니다.

## 💬 리뷰 요구사항(선택)

빨리 작업해야 하는 내용이기 때문에 바로 머지하겠습니다!
