### PR TITLE
Feature/#155 스터디 조회 정보에 스터디 진행률을 포함한다

### DIFF
--- a/src/main/java/doore/study/application/dto/response/StudyResponse.java
+++ b/src/main/java/doore/study/application/dto/response/StudyResponse.java
@@ -21,9 +21,11 @@ public record StudyResponse(
         LocalDate endDate,
         StudyStatus status,
         TeamReferenceResponse teamReference,
-        CropReferenceResponse cropReference
+        CropReferenceResponse cropReference,
+        long studyProgressRatio
+
 ) {
-    public static StudyResponse of(final Study study, final Team team, final Crop crop) {
+    public static StudyResponse of(final Study study, final Team team, final Crop crop, final long studyProgressRatio) {
         return StudyResponse.builder()
                 .id(study.getId())
                 .name(study.getName())
@@ -33,6 +35,7 @@ public record StudyResponse(
                 .status(study.getStatus())
                 .teamReference(TeamReferenceResponse.from(team))
                 .cropReference(CropReferenceResponse.from(crop))
+                .studyProgressRatio(studyProgressRatio)
                 .build();
     }
 }

--- a/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
+++ b/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
@@ -4,7 +4,6 @@ import doore.study.domain.CurriculumItem;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface CurriculumItemRepository extends JpaRepository<CurriculumItem, Long> {
     List<CurriculumItem> findAllByOrderByItemOrderAsc();
@@ -14,5 +13,5 @@ public interface CurriculumItemRepository extends JpaRepository<CurriculumItem, 
     void deleteAllByStudyId(Long studyId);
 
     @Query("SELECT ci.id FROM CurriculumItem ci WHERE ci.study.id = :studyId")
-    List<Long> findIdsByStudyId(@Param("studyId") Long studyId);
+    List<Long> findIdsByStudyId(Long studyId);
 }

--- a/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
+++ b/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
@@ -3,6 +3,8 @@ package doore.study.domain.repository;
 import doore.study.domain.CurriculumItem;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CurriculumItemRepository extends JpaRepository<CurriculumItem, Long> {
     List<CurriculumItem> findAllByOrderByItemOrderAsc();
@@ -10,4 +12,7 @@ public interface CurriculumItemRepository extends JpaRepository<CurriculumItem, 
     List<CurriculumItem> findAllByStudyId(Long studyId);
 
     void deleteAllByStudyId(Long studyId);
+
+    @Query("SELECT ci.id FROM CurriculumItem ci WHERE ci.study.id = :studyId")
+    List<Long> findIdsByStudyId(@Param("studyId") Long studyId);
 }

--- a/src/main/java/doore/study/domain/repository/ParticipantCurriculumItemRepository.java
+++ b/src/main/java/doore/study/domain/repository/ParticipantCurriculumItemRepository.java
@@ -20,4 +20,8 @@ public interface ParticipantCurriculumItemRepository extends JpaRepository<Parti
     List<ParticipantCurriculumItem> findAllByCurriculumItemId(Long curriculumId);
 
     void deleteAllByCurriculumItemId(Long curriculumItemId);
+
+    long countByCurriculumItemIdIn(List<Long> curriculumIds);
+
+    long countByCurriculumItemIdInAndIsCheckedTrue(List<Long> curriculumIds);
 }

--- a/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/StudyApiDocsTest.java
@@ -94,6 +94,7 @@ public class StudyApiDocsTest extends RestDocsTest {
                 .status(StudyStatus.IN_PROGRESS)
                 .teamReference(teamReferenceResponse)
                 .cropReference(cropReferenceResponse)
+                .studyProgressRatio(50)
                 .build();
     }
 
@@ -187,7 +188,8 @@ public class StudyApiDocsTest extends RestDocsTest {
                 stringFieldWithPath("[].teamReference.imageUrl", "스터디가 속한 팀의 이미지 url"),
                 numberFieldWithPath("[].cropReference.id", "스터디의 작물의 ID"),
                 stringFieldWithPath("[].cropReference.name", "스터디의 작물의 이름"),
-                stringFieldWithPath("[].cropReference.imageUrl", "스터디의 작물의 이미지 url")
+                stringFieldWithPath("[].cropReference.imageUrl", "스터디의 작물의 이미지 url"),
+                numberFieldWithPath("[].studyProgressRatio", "스터디 진행률")
         );
 
         when(studyQueryService.findMyStudies(any(), any())).thenReturn(response);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #155 

## 📝 작업 내용

- 스터디 조회 api와 나의 스터디 조회 api에 스터디 진행률을 추가하였습니다.
- 스터디 조회만 추가할까 하다가 나의 스터디 조회에도 추가해도 좋을 것 같아서 추가했습니다!

## 💬 리뷰 요구사항
- 계산 식 저거 맞죠..?
- 테스트는 로컬에서 통과하는데, cicd 오류 부분을 아직 고치지 않았기 때문에 disable 처리해두었습니다! (오류 해결하면서 풀어두겠습니다)

