### PR TITLE
Feature/#149 팀 랭킹 조회에 텃밭 데이터를 추가한다

### DIFF
--- a/src/main/java/doore/team/api/TeamController.java
+++ b/src/main/java/doore/team/api/TeamController.java
@@ -112,9 +112,9 @@ public class TeamController {
         return ResponseEntity.ok(teamQueryService.findTeamByTeamId(teamId));
     }
 
-    @GetMapping
+    @GetMapping // 비회원
     public ResponseEntity<List<TeamRankResponse>> getTeams(
-    ) { //비회원
+    ) {
         final List<TeamRankResponse> teamRankResponses = teamQueryService.getTeamRanks();
         return ResponseEntity.ok(teamRankResponses);
     }

--- a/src/main/java/doore/team/application/TeamQueryService.java
+++ b/src/main/java/doore/team/application/TeamQueryService.java
@@ -23,10 +23,8 @@ import doore.team.domain.Team;
 import doore.team.domain.TeamRepository;
 import doore.team.exception.TeamException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -97,22 +95,22 @@ public class TeamQueryService {
     }
 
     public List<TeamRankResponse> getTeamRanks() {
-        Map<Integer, TeamReferenceResponse> teamRanks = calculateTeamRanks();
-        return teamRanks.entrySet().stream()
-                .map(entry -> new TeamRankResponse(entry.getKey(), entry.getValue()))
+        List<Team> teams = teamRepository.findAll();
+        List<TeamRankResponse> teamRanks = new ArrayList<>();
+        for (Team team : teams) {
+            final int point = calculatePoint(team);
+            final List<DayGardenResponse> yearGardenResponses = gardenQueryService.getAllGarden(team.getId());
+            teamRanks.add(new TeamRankResponse(point, TeamReferenceResponse.from(team), yearGardenResponses));
+        }
+        return teamRanks.stream()
+                .sorted(Comparator.comparingInt(TeamRankResponse::point).reversed())
                 .toList();
     }
 
-    private Map<Integer, TeamReferenceResponse> calculateTeamRanks() {
-        List<Team> teams = teamRepository.findAll();
-        Map<Integer, TeamReferenceResponse> teamRanks = new TreeMap<>(Collections.reverseOrder());
-        for (Team team : teams) {
-            List<DayGardenResponse> gardenResponses = gardenQueryService.getThisWeekGarden(team.getId());
-            Integer point = gardenResponses.stream()
-                    .mapToInt(DayGardenResponse::contributeCount)
-                    .sum();
-            teamRanks.put(point, TeamReferenceResponse.from(team));
-        }
-        return teamRanks;
+    private int calculatePoint(final Team team) {
+        final List<DayGardenResponse> weekGardenResponses = gardenQueryService.getThisWeekGarden(team.getId());
+        return weekGardenResponses.stream()
+                .mapToInt(DayGardenResponse::contributeCount)
+                .sum();
     }
 }

--- a/src/main/java/doore/team/application/TeamQueryService.java
+++ b/src/main/java/doore/team/application/TeamQueryService.java
@@ -4,6 +4,7 @@ import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
+import com.google.common.collect.ImmutableList;
 import doore.attendance.domain.Attendance;
 import doore.attendance.domain.repository.AttendanceRepository;
 import doore.garden.application.GardenQueryService;
@@ -25,6 +26,7 @@ import doore.team.exception.TeamException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -95,16 +97,17 @@ public class TeamQueryService {
     }
 
     public List<TeamRankResponse> getTeamRanks() {
-        List<Team> teams = teamRepository.findAll();
-        List<TeamRankResponse> teamRanks = new ArrayList<>();
-        for (Team team : teams) {
-            final int point = calculatePoint(team);
-            final List<DayGardenResponse> yearGardenResponses = gardenQueryService.getAllGarden(team.getId());
-            teamRanks.add(new TeamRankResponse(point, TeamReferenceResponse.from(team), yearGardenResponses));
-        }
+        final List<Team> teams = teamRepository.findAll();
+        List<TeamRankResponse> teamRanks = teams.stream().map(this::convertTeamToTeamRankResponse).toList();
         return teamRanks.stream()
                 .sorted(Comparator.comparingInt(TeamRankResponse::point).reversed())
                 .toList();
+    }
+
+    private TeamRankResponse convertTeamToTeamRankResponse(Team team) {
+        final int point = calculatePoint(team);
+        final List<DayGardenResponse> yearGardenResponses = gardenQueryService.getAllGarden(team.getId());
+        return new TeamRankResponse(point, TeamReferenceResponse.from(team), yearGardenResponses);
     }
 
     private int calculatePoint(final Team team) {

--- a/src/main/java/doore/team/application/dto/response/TeamRankResponse.java
+++ b/src/main/java/doore/team/application/dto/response/TeamRankResponse.java
@@ -1,7 +1,11 @@
 package doore.team.application.dto.response;
 
+import doore.garden.application.dto.response.DayGardenResponse;
+import java.util.List;
+
 public record TeamRankResponse(
         int point,
-        TeamReferenceResponse teamReferenceResponse
+        TeamReferenceResponse teamReferenceResponse,
+        List<DayGardenResponse> teamGardenResponse
 ) {
 }

--- a/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
@@ -19,6 +19,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import doore.garden.application.dto.response.DayGardenResponse;
 import doore.restdocs.RestDocsTest;
 import doore.study.application.dto.response.StudyNameResponse;
 import doore.team.application.dto.request.TeamCreateRequest;
@@ -29,7 +30,9 @@ import doore.team.application.dto.response.TeamInviteCodeResponse;
 import doore.team.application.dto.response.TeamRankResponse;
 import doore.team.application.dto.response.TeamReferenceResponse;
 import doore.team.application.dto.response.TeamResponse;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -308,15 +311,40 @@ public class TeamApiDocsTest extends RestDocsTest {
     @DisplayName("팀 목록(팀 랭킹)을 조회한다.")
     public void 팀_목록팀_랭킹을_조회한다() throws Exception {
         //given
-        Map<Integer, TeamReferenceResponse> teamRanks = new TreeMap<>(Collections.reverseOrder());
-        teamRanks.put(5, new TeamReferenceResponse(1L, "팀1", "팀 설명입니다", "팀 이미지 Url"));
-        teamRanks.put(15, new TeamReferenceResponse(2L, "팀2", "팀 설명입니다", "팀 이미지 Url"));
-        teamRanks.put(20, new TeamReferenceResponse(3L, "팀3", "팀 설명입니다", "팀 이미지 Url"));
-        teamRanks.put(0, new TeamReferenceResponse(4L, "팀4", "팀 설명입니다", "팀 이미지 Url"));
+        final List<TeamRankResponse> teamRankResponses = new ArrayList<>();
+        final List<DayGardenResponse> yearGardenResponses = List.of(
+                DayGardenResponse.builder()
+                        .dayOfYear(0)
+                        .weekOfYear(0)
+                        .dayOfWeek(0)
+                        .contributeCount(2)
+                        .build(),
+                DayGardenResponse.builder()
+                        .dayOfYear(1)
+                        .weekOfYear(0)
+                        .dayOfWeek(1)
+                        .contributeCount(1)
+                        .build(),
+                DayGardenResponse.builder()
+                        .dayOfYear(7)
+                        .weekOfYear(1)
+                        .dayOfWeek(0)
+                        .contributeCount(5)
+                        .build()
+        );
+        teamRankResponses.add(new TeamRankResponse(20,
+                new TeamReferenceResponse(3L, "팀3", "팀 설명입니다", "팀 이미지 Url"),
+                yearGardenResponses));
+        teamRankResponses.add(new TeamRankResponse(15,
+                new TeamReferenceResponse(2L, "팀2", "팀 설명입니다", "팀 이미지 Url"),
+                yearGardenResponses));
+        teamRankResponses.add(new TeamRankResponse(5,
+                new TeamReferenceResponse(1L, "팀1", "팀 설명입니다", "팀 이미지 Url"),
+                yearGardenResponses));
+        teamRankResponses.add(new TeamRankResponse(0,
+                new TeamReferenceResponse(4L, "팀4", "팀 설명입니다", "팀 이미지 Url"),
+                yearGardenResponses));
 
-        List<TeamRankResponse> teamRankResponses = teamRanks.entrySet().stream()
-                .map(entry -> new TeamRankResponse(entry.getKey(), entry.getValue()))
-                .toList();
         System.out.println(teamRankResponses.get(0));
         //when
         when(teamQueryService.getTeamRanks()).thenReturn(teamRankResponses);
@@ -327,7 +355,11 @@ public class TeamApiDocsTest extends RestDocsTest {
                 numberFieldWithPath("[].teamReferenceResponse.id", "팀의 ID"),
                 stringFieldWithPath("[].teamReferenceResponse.name", "팀의 이름"),
                 stringFieldWithPath("[].teamReferenceResponse.description", "팀의 설명"),
-                stringFieldWithPath("[].teamReferenceResponse.imageUrl", "팀의 이미지 URL")
+                stringFieldWithPath("[].teamReferenceResponse.imageUrl", "팀의 이미지 URL"),
+                numberFieldWithPath("[].teamGardenResponse.[].dayOfYear", "1년 중 몇번째 날인가(0~365)"),
+                numberFieldWithPath("[].teamGardenResponse.[].dayOfWeek", "1주 중 몇번째 요일인가(월요일부터 시작, 0~7)"),
+                numberFieldWithPath("[].teamGardenResponse.[].weekOfYear", "1년 중 몇번째 주인가(0~52)"),
+                numberFieldWithPath("[].teamGardenResponse.[].contributeCount", "그날의 기여도(기여된 횟수)")
         );
 
         mockMvc.perform(get("/teams")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #149

## 📝 작업 내용

팀 랭킹 조회시 텃밭데이터를 추가하도록 수정했습니다. 

## 💬 리뷰 요구사항(선택)

수정 내역중에 final이 붙은 상수와 붙지 않은 상수가 섞여 있을텐데 그 내용은 final 추가 PR 머지되면 수정하겠습니다!  

