### PR TITLE
Feature/#164 팀의 garden 조회 로직을 수정한다

### DIFF
--- a/src/docs/asciidoc/garden.adoc
+++ b/src/docs/asciidoc/garden.adoc
@@ -2,7 +2,7 @@ ifndef::snippets[]
 :snippets: ./build/generated-snippets
 endif::[]
 
-= ATTENDANCE API 문서
+= Garden API 문서
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
@@ -15,16 +15,18 @@ endif::[]
 link:../doore.html[API 목록으로 돌아가기]
 
 
-== `GET`: 1년치 잔디 조회
+== `GET`: 텃밭 조회
+
+NOTE: 최근 15주(월요일부터 시작)의 텃밭 데이터를 조회합니다.
 
 .HTTP Request
-include::{snippets}/garden-get-all/http-request.adoc[]
+include::{snippets}/garden-get/http-request.adoc[]
 
 .Path Parameters
-include::{snippets}/garden-get-all/path-parameters.adoc[]
+include::{snippets}/garden-get/path-parameters.adoc[]
 
 .Response Body
-include::{snippets}/garden-get-all/response-body.adoc[]
+include::{snippets}/garden-get/response-body.adoc[]
 
 .Response Fields
-include::{snippets}/garden-get-all/response-fields.adoc[]
+include::{snippets}/garden-get/response-fields.adoc[]

--- a/src/main/java/doore/garden/api/GardenController.java
+++ b/src/main/java/doore/garden/api/GardenController.java
@@ -18,8 +18,8 @@ public class GardenController {
     private final GardenQueryService gardenQueryService;
 
     @GetMapping("/{teamId}")
-    public ResponseEntity<List<DayGardenResponse>> getAllGarden(@PathVariable final Long teamId) {
-        final List<DayGardenResponse> fullGardenResponse = gardenQueryService.getAllGarden(teamId);
-        return ResponseEntity.status(HttpStatus.OK).body(fullGardenResponse);
+    public ResponseEntity<List<DayGardenResponse>> getGardens(@PathVariable final Long teamId) {
+        final List<DayGardenResponse> gardenResponse = gardenQueryService.getGardens(teamId);
+        return ResponseEntity.status(HttpStatus.OK).body(gardenResponse);
     }
 }

--- a/src/main/java/doore/garden/application/GardenQueryService.java
+++ b/src/main/java/doore/garden/application/GardenQueryService.java
@@ -14,9 +14,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GardenQueryService {
     private final GardenRepository gardenRepository;
+    private static final int RECENT_WEEK_NUMBER = 13;
 
-    public List<DayGardenResponse> getAllGarden(final Long teamId) {
-        final List<Garden> gardens = gardenRepository.findAllOfThisYearByTeamIdOrderByContributedDateAsc(teamId);
+    public List<DayGardenResponse> getGardens(final Long teamId) {
+        final List<Garden> gardens = gardenRepository.findRecentNthWeekGardenByTeamIdOrderByContributedDateAsc(teamId, RECENT_WEEK_NUMBER);
         return calculateContributes(gardens);
     }
 

--- a/src/main/java/doore/garden/application/dto/response/DayGardenResponse.java
+++ b/src/main/java/doore/garden/application/dto/response/DayGardenResponse.java
@@ -6,32 +6,19 @@ import java.util.Locale;
 import lombok.Builder;
 
 public record DayGardenResponse(
-        int dayOfYear,
-        int dayOfWeek,
-        int weekOfYear,
+        LocalDate contributeDate,
         int contributeCount
 ) {
     @Builder
-    public DayGardenResponse(final int dayOfYear, final int dayOfWeek, final int weekOfYear, final int contributeCount) {
-        this.dayOfYear = dayOfYear;
-        this.dayOfWeek = dayOfWeek;
-        this.weekOfYear = weekOfYear;
+    public DayGardenResponse(final LocalDate contributeDate, final int contributeCount) {
+        this.contributeDate = contributeDate;
         this.contributeCount = contributeCount;
     }
 
     public static DayGardenResponse of(final LocalDate date, final int contributeNumber) {
-        final int weekOfYear = getWeekOfYear(date)-1;
-        final int dayOfWeek = date.getDayOfWeek().getValue() - 1;
         return DayGardenResponse.builder()
-                .dayOfYear(date.getDayOfYear() - 1)
-                .weekOfYear(weekOfYear)
-                .dayOfWeek(dayOfWeek)
+                .contributeDate(date)
                 .contributeCount(contributeNumber)
                 .build();
-    }
-
-    private static int getWeekOfYear(final LocalDate date) {
-        final WeekFields weekFields = WeekFields.of(Locale.KOREA);
-        return date.get(weekFields.weekOfWeekBasedYear());
     }
 }

--- a/src/main/java/doore/garden/domain/repository/GardenRepository.java
+++ b/src/main/java/doore/garden/domain/repository/GardenRepository.java
@@ -8,15 +8,15 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface GardenRepository extends JpaRepository<Garden,Long> {
     void deleteByContributionIdAndType(Long contributionId, GardenType gardenType);
-    @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND YEAR(g.contributedDate) = YEAR(CURRENT_DATE) ORDER BY g.contributedDate ASC")
+    @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND YEAR(g.contributedDate) = YEAR(CURRENT_DATE)")
     List<Garden> findAllOfThisYearByTeamIdOrderByContributedDateAsc(Long teamId); //올해의 데이터만 가져온다.
 
     @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND g.contributedDate = CURRENT_DATE")
     List<Garden> findTodayGardenByTeamId(Long teamId); //오늘의 데이터만 가져온다.
 
-    @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND YEARWEEK(g.contributedDate, 1) = YEARWEEK(CURRENT_DATE, 1) ORDER BY g.contributedDate ASC")
+    @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND YEARWEEK(g.contributedDate, 1) = YEARWEEK(CURRENT_DATE, 1)")
     List<Garden> findThisWeekGardenByTeamId(Long teamId); //이번주의 데이터만 가져온다.(월~일)
 
-    @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND YEARWEEK(g.contributedDate, 1) >= YEARWEEK(CURRENT_DATE, 1) - :recentWeekNumber ORDER BY g.contributedDate ASC")
+    @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND YEARWEEK(g.contributedDate, 1) >= YEARWEEK(CURRENT_DATE, 1) - :recentWeekNumber")
     List<Garden> findRecentNthWeekGardenByTeamIdOrderByContributedDateAsc(Long teamId, Integer recentWeekNumber); //최근 n주의 데이터만 가져온다.
 }

--- a/src/main/java/doore/garden/domain/repository/GardenRepository.java
+++ b/src/main/java/doore/garden/domain/repository/GardenRepository.java
@@ -16,4 +16,7 @@ public interface GardenRepository extends JpaRepository<Garden,Long> {
 
     @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND YEARWEEK(g.contributedDate, 1) = YEARWEEK(CURRENT_DATE, 1) ORDER BY g.contributedDate ASC")
     List<Garden> findThisWeekGardenByTeamId(Long teamId); //이번주의 데이터만 가져온다.(월~일)
+
+    @Query("SELECT g FROM Garden g WHERE g.teamId = :teamId AND YEARWEEK(g.contributedDate, 1) >= YEARWEEK(CURRENT_DATE, 1) - :recentWeekNumber ORDER BY g.contributedDate ASC")
+    List<Garden> findRecentNthWeekGardenByTeamIdOrderByContributedDateAsc(Long teamId, Integer recentWeekNumber); //최근 n주의 데이터만 가져온다.
 }

--- a/src/main/java/doore/team/application/TeamQueryService.java
+++ b/src/main/java/doore/team/application/TeamQueryService.java
@@ -105,7 +105,7 @@ public class TeamQueryService {
 
     private TeamRankResponse convertTeamToTeamRankResponse(final Team team) {
         final int point = calculatePoint(team);
-        final List<DayGardenResponse> yearGardenResponses = gardenQueryService.getAllGarden(team.getId());
+        final List<DayGardenResponse> yearGardenResponses = gardenQueryService.getGardens(team.getId());
         return new TeamRankResponse(point, TeamReferenceResponse.from(team), yearGardenResponses);
     }
 

--- a/src/test/java/doore/garden/application/GardenQueryServiceTest.java
+++ b/src/test/java/doore/garden/application/GardenQueryServiceTest.java
@@ -1,5 +1,6 @@
 package doore.garden.application;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import doore.garden.application.dto.response.DayGardenResponse;
@@ -9,6 +10,7 @@ import doore.garden.domain.repository.GardenRepository;
 import doore.helper.IntegrationTest;
 import java.time.LocalDate;
 import java.util.List;
+import net.bytebuddy.asm.Advice.Local;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +25,7 @@ public class GardenQueryServiceTest extends IntegrationTest {
 
     @Test
     @DisplayName("[성공] 팀의 텃밭을 정상적으로 조회할 수 있다.")
-    public void getAllGarden_팀의_텃밭을_정상적으로_조회할_수_있다_성공() throws Exception {
+    public void getGardens_팀의_텃밭을_정상적으로_조회할_수_있다_성공() throws Exception {
         //given
         final Long teamId = 1L;
         final Long otherTeamId = 2L;
@@ -34,8 +36,8 @@ public class GardenQueryServiceTest extends IntegrationTest {
                 .contributionId(1L)
                 .type(GardenType.DOCUMENT_UPLOAD)
                 .build();
-        final Garden lastYearGarden = Garden.builder()
-                .contributedDate(LocalDate.now().minusYears(1))
+        final Garden before15WeeksGarden = Garden.builder()
+                .contributedDate(LocalDate.now().minusWeeks(15))
                 .teamId(teamId)
                 .memberId(1L)
                 .contributionId(2L)
@@ -49,33 +51,76 @@ public class GardenQueryServiceTest extends IntegrationTest {
                 .type(GardenType.STUDY_CURRICULUM_COMPLETION)
                 .build();
 
-        gardenRepository.saveAll(List.of(garden, lastYearGarden, otherTeamGarden));
+        gardenRepository.saveAll(List.of(garden, before15WeeksGarden, otherTeamGarden));
 
         //when
         final List<Garden> allGardens = gardenRepository.findAll();
-        assertEquals(1, gardenRepository.findAllOfThisYearByTeamIdOrderByContributedDateAsc(teamId).size());
-        final List<DayGardenResponse> gardenResponses = gardenQueryService.getAllGarden(teamId);
+        final List<DayGardenResponse> gardenResponses = gardenQueryService.getGardens(teamId);
 
         //then
         assertEquals(3, allGardens.size());
-        assertEquals(1, gardenResponses.size()); //올해의 텃밭 데이터만 가져온다, 우리 팀의 텃밭 데이터만 가져온다.
+        assertEquals(1, gardenResponses.size()); //최근 15주의 텃밭 데이터만 가져온다, 우리 팀의 텃밭 데이터만 가져온다.
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 텃밭은 기여된 날짜를 기준으로 오름차 정렬된다.")
+    public void getGardens_팀의_텃밭은_기여된_날짜를_기준으로_오름차_정렬된다_성공() throws Exception {
+        //given
+        final Long teamId = 1L;
+        final LocalDate now = LocalDate.now();
+        final LocalDate before1Week = now.minusWeeks(1);
+        final LocalDate before2Week = now.minusWeeks(2);
+        final Garden garden = Garden.builder()
+                .contributedDate(now)
+                .teamId(teamId)
+                .memberId(1L)
+                .contributionId(1L)
+                .type(GardenType.DOCUMENT_UPLOAD)
+                .build();
+        final Garden before1WeekGarden = Garden.builder()
+                .contributedDate(before1Week)
+                .teamId(teamId)
+                .memberId(1L)
+                .contributionId(2L)
+                .type(GardenType.STUDY_CURRICULUM_COMPLETION)
+                .build();
+        final Garden before2WeekGarden = Garden.builder()
+                .contributedDate(before2Week)
+                .teamId(teamId)
+                .memberId(1L)
+                .contributionId(3L)
+                .type(GardenType.STUDY_CURRICULUM_COMPLETION)
+                .build();
+
+        gardenRepository.saveAll(List.of(before1WeekGarden, before2WeekGarden, garden));
+
+        //when
+        final List<Garden> allGardens = gardenRepository.findAll();
+        final List<DayGardenResponse> gardenResponses = gardenQueryService.getGardens(teamId);
+
+        //then
+        assertAll(() -> {
+            assertEquals(now, gardenResponses.get(0).contributeDate());
+            assertEquals(before1Week, gardenResponses.get(1).contributeDate());
+            assertEquals(before2WeekGarden, gardenResponses.get(2).contributeDate());
+        });
     }
 
     @Test
     @DisplayName("[성공] 정상적으로 동일한 날의 기여도를 계산할 수 있다.")
     public void calculateContributes_정상적으로_동일한_날의_기여도를_계산할_수_있다_성공() throws Exception {
         //given
-        final LocalDate January1st = LocalDate.of(LocalDate.now().getYear(), 1, 1);
+        final LocalDate before1Week = LocalDate.now().minusWeeks(1);
         final Long teamId = 1L;
         final Garden todaysGarden = Garden.builder()
-                .contributedDate(January1st)
+                .contributedDate(before1Week)
                 .teamId(teamId)
                 .memberId(1L)
                 .contributionId(1L)
                 .type(GardenType.DOCUMENT_UPLOAD)
                 .build();
         final Garden otherTodaysGarden = Garden.builder()
-                .contributedDate(January1st)
+                .contributedDate(before1Week)
                 .teamId(teamId)
                 .memberId(1L)
                 .contributionId(2L)
@@ -85,12 +130,11 @@ public class GardenQueryServiceTest extends IntegrationTest {
         gardenRepository.saveAll(gardens);
 
         //when
-        final List<DayGardenResponse> gardenResponses = gardenQueryService.getAllGarden(teamId);
+        final List<DayGardenResponse> gardenResponses = gardenQueryService.getGardens(teamId);
 
         //then
         assertEquals(1, gardenResponses.size());
         assertEquals(2, gardenResponses.get(0).contributeCount());
-        assertEquals(0, gardenResponses.get(0).dayOfYear());
-        assertEquals(0, gardenResponses.get(0).weekOfYear());
+        assertEquals(before1Week, gardenResponses.get(0).contributeDate());
     }
 }

--- a/src/test/java/doore/garden/application/GardenQueryServiceTest.java
+++ b/src/test/java/doore/garden/application/GardenQueryServiceTest.java
@@ -63,50 +63,6 @@ public class GardenQueryServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[성공] 팀의 텃밭은 기여된 날짜를 기준으로 오름차 정렬된다.")
-    public void getGardens_팀의_텃밭은_기여된_날짜를_기준으로_오름차_정렬된다_성공() throws Exception {
-        //given
-        final Long teamId = 1L;
-        final LocalDate now = LocalDate.now();
-        final LocalDate before1Week = now.minusWeeks(1);
-        final LocalDate before2Week = now.minusWeeks(2);
-        final Garden garden = Garden.builder()
-                .contributedDate(now)
-                .teamId(teamId)
-                .memberId(1L)
-                .contributionId(1L)
-                .type(GardenType.DOCUMENT_UPLOAD)
-                .build();
-        final Garden before1WeekGarden = Garden.builder()
-                .contributedDate(before1Week)
-                .teamId(teamId)
-                .memberId(1L)
-                .contributionId(2L)
-                .type(GardenType.STUDY_CURRICULUM_COMPLETION)
-                .build();
-        final Garden before2WeekGarden = Garden.builder()
-                .contributedDate(before2Week)
-                .teamId(teamId)
-                .memberId(1L)
-                .contributionId(3L)
-                .type(GardenType.STUDY_CURRICULUM_COMPLETION)
-                .build();
-
-        gardenRepository.saveAll(List.of(before1WeekGarden, before2WeekGarden, garden));
-
-        //when
-        final List<Garden> allGardens = gardenRepository.findAll();
-        final List<DayGardenResponse> gardenResponses = gardenQueryService.getGardens(teamId);
-
-        //then
-        assertAll(() -> {
-            assertEquals(now, gardenResponses.get(0).contributeDate());
-            assertEquals(before1Week, gardenResponses.get(1).contributeDate());
-            assertEquals(before2WeekGarden, gardenResponses.get(2).contributeDate());
-        });
-    }
-
-    @Test
     @DisplayName("[성공] 정상적으로 동일한 날의 기여도를 계산할 수 있다.")
     public void calculateContributes_정상적으로_동일한_날의_기여도를_계산할_수_있다_성공() throws Exception {
         //given

--- a/src/test/java/doore/restdocs/docs/GardenApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/GardenApiDocsTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import doore.garden.application.dto.response.DayGardenResponse;
 import doore.restdocs.RestDocsTest;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,39 +24,31 @@ public class GardenApiDocsTest extends RestDocsTest {
     @DisplayName("[성공] 팀의 올해 텃밭을 조회한다.")
     public void getAllGarden_팀의_올해_텃밭을_생성한다() throws Exception {
         //given
-        final List<DayGardenResponse> fullGardenResponse = List.of(
+        final List<DayGardenResponse> gardenResponse = List.of(
                 DayGardenResponse.builder()
-                        .dayOfYear(0)
-                        .weekOfYear(0)
-                        .dayOfWeek(0)
+                        .contributeDate(LocalDate.of(2024,1,1))
                         .contributeCount(2)
                         .build(),
                 DayGardenResponse.builder()
-                        .dayOfYear(1)
-                        .weekOfYear(0)
-                        .dayOfWeek(1)
+                        .contributeDate(LocalDate.of(2024,1,2))
                         .contributeCount(1)
                         .build(),
                 DayGardenResponse.builder()
-                        .dayOfYear(7)
-                        .weekOfYear(1)
-                        .dayOfWeek(0)
+                        .contributeDate(LocalDate.of(2024,1,7))
                         .contributeCount(5)
                         .build()
         );
 
         //when
-        when(gardenQueryService.getAllGarden(any())).thenReturn(fullGardenResponse);
+        when(gardenQueryService.getGardens(any())).thenReturn(gardenResponse);
 
         //then
         mockMvc.perform(get("/garden/{teamId}", 1))
                 .andExpect(status().isOk())
-                .andDo(document("garden-get-all",
+                .andDo(document("garden-get",
                         pathParameters(parameterWithName("teamId").description("팀 id")),
                         responseFields(
-                                numberFieldWithPath("[].dayOfYear", "1년 중 몇번째 날인가(0~365)"),
-                                numberFieldWithPath("[].weekOfYear", "1년 중 몇번째 주인가(0~52)"),
-                                numberFieldWithPath("[].dayOfWeek", "1주 중 몇번째 요일인가(월요일부터 시작, 0~7)"),
+                                numberFieldWithPath("[].contributeDate", "기여된 날짜"),
                                 numberFieldWithPath("[].contributeCount", "그날의 기여도(기여된 횟수)")
                         )));
     }

--- a/src/test/java/doore/restdocs/docs/GardenApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/GardenApiDocsTest.java
@@ -48,7 +48,7 @@ public class GardenApiDocsTest extends RestDocsTest {
                 .andDo(document("garden-get",
                         pathParameters(parameterWithName("teamId").description("팀 id")),
                         responseFields(
-                                numberFieldWithPath("[].contributeDate", "기여된 날짜"),
+                                stringFieldWithPath("[].contributeDate", "기여된 날짜"),
                                 numberFieldWithPath("[].contributeCount", "그날의 기여도(기여된 횟수)")
                         )));
     }

--- a/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
@@ -350,9 +350,7 @@ public class TeamApiDocsTest extends RestDocsTest {
                 stringFieldWithPath("[].teamReferenceResponse.name", "팀의 이름"),
                 stringFieldWithPath("[].teamReferenceResponse.description", "팀의 설명"),
                 stringFieldWithPath("[].teamReferenceResponse.imageUrl", "팀의 이미지 URL"),
-                numberFieldWithPath("[].teamGardenResponse.[].dayOfYear", "1년 중 몇번째 날인가(0~365)"),
-                numberFieldWithPath("[].teamGardenResponse.[].dayOfWeek", "1주 중 몇번째 요일인가(월요일부터 시작, 0~7)"),
-                numberFieldWithPath("[].teamGardenResponse.[].weekOfYear", "1년 중 몇번째 주인가(0~52)"),
+                stringFieldWithPath("[].teamGardenResponse.[].contributeDate", "기여된 날짜"),
                 numberFieldWithPath("[].teamGardenResponse.[].contributeCount", "그날의 기여도(기여된 횟수)")
         );
 

--- a/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
@@ -30,6 +30,7 @@ import doore.team.application.dto.response.TeamInviteCodeResponse;
 import doore.team.application.dto.response.TeamRankResponse;
 import doore.team.application.dto.response.TeamReferenceResponse;
 import doore.team.application.dto.response.TeamResponse;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -312,38 +313,32 @@ public class TeamApiDocsTest extends RestDocsTest {
     public void 팀_목록팀_랭킹을_조회한다() throws Exception {
         //given
         final List<TeamRankResponse> teamRankResponses = new ArrayList<>();
-        final List<DayGardenResponse> yearGardenResponses = List.of(
+        final List<DayGardenResponse> gardenResponse = List.of(
                 DayGardenResponse.builder()
-                        .dayOfYear(0)
-                        .weekOfYear(0)
-                        .dayOfWeek(0)
+                        .contributeDate(LocalDate.of(2024,1,1))
                         .contributeCount(2)
                         .build(),
                 DayGardenResponse.builder()
-                        .dayOfYear(1)
-                        .weekOfYear(0)
-                        .dayOfWeek(1)
+                        .contributeDate(LocalDate.of(2024,1,2))
                         .contributeCount(1)
                         .build(),
                 DayGardenResponse.builder()
-                        .dayOfYear(7)
-                        .weekOfYear(1)
-                        .dayOfWeek(0)
+                        .contributeDate(LocalDate.of(2024,1,7))
                         .contributeCount(5)
                         .build()
         );
         teamRankResponses.add(new TeamRankResponse(20,
                 new TeamReferenceResponse(3L, "팀3", "팀 설명입니다", "팀 이미지 Url"),
-                yearGardenResponses));
+                gardenResponse));
         teamRankResponses.add(new TeamRankResponse(15,
                 new TeamReferenceResponse(2L, "팀2", "팀 설명입니다", "팀 이미지 Url"),
-                yearGardenResponses));
+                gardenResponse));
         teamRankResponses.add(new TeamRankResponse(5,
                 new TeamReferenceResponse(1L, "팀1", "팀 설명입니다", "팀 이미지 Url"),
-                yearGardenResponses));
+                gardenResponse));
         teamRankResponses.add(new TeamRankResponse(0,
                 new TeamReferenceResponse(4L, "팀4", "팀 설명입니다", "팀 이미지 Url"),
-                yearGardenResponses));
+                gardenResponse));
 
         //when
         when(teamQueryService.getTeamRanks()).thenReturn(teamRankResponses);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #164

## 📝 작업 내용

기존:
- 올해 기여된 전체 Garden 데이터를 조회한다.
- ~contribution이 없는 날의 garden 데이터는 조회하지 않는다.~
- dto 필드: int dayOfYear, int dayOfWeek, int weekOfYear, int contributeCount


수정:
- 최근 13주 동안의 Garden 데이터를 조회한다. (월요일부터 시작함)
- ~contribution이 없는 날의 garden 데이터도 조회한다.~
- dto 필드: localDate contributionDate, int contributionCount

## 💬 리뷰 요구사항(선택)

프론트 요청사항에 따라 팀의 garden 조회 로직과 형태를 수정했습니다.
기존에는 조회 쿼리에 정렬 로직이 존재했는데 작동되지 않는 것 같아서 (아마도 YEAR, YEARWEEK 등의 함수 사용 때문에...) 삭제했습니다  (프론트에서 정렬 로직 필요없다고도 해서)
