### PR TITLE
Feature/#174 학습자료 조회 시 uploader 정보 조회 추가

### DIFF
--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -13,7 +13,6 @@ import doore.document.application.dto.response.DocumentDetailResponse;
 import doore.document.application.dto.response.FileResponse;
 import doore.document.domain.Document;
 import doore.document.domain.DocumentGroupType;
-import doore.document.domain.File;
 import doore.document.domain.repository.DocumentRepository;
 import doore.document.exception.DocumentException;
 import doore.member.domain.StudyRole;
@@ -22,7 +21,6 @@ import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.exception.MemberException;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -65,17 +63,17 @@ public class DocumentQueryService {
     }
 
     private DocumentDetailResponse toDocumentDetailResponse(final Document document) {
-        final List<FileResponse> fileResponses = new ArrayList<>();
-        for (final File file : document.getFiles()) {
-            final FileResponse fileResponse = new FileResponse(file.getId(), file.getUrl());
-            fileResponses.add(fileResponse);
-        }
+        final List<FileResponse> fileResponses = document.getFiles().stream()
+                .map(file -> new FileResponse(file.getId(), file.getUrl()))
+                .toList();
+
         final String uploaderName = memberRepository.findById(document.getUploaderId())
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER))
                 .getName();
 
         return DocumentDetailResponse.of(document, fileResponses, uploaderName);
     }
+
 
     private void validateExistMember(final Long memberId) {
         memberRepository.findById(memberId).orElseThrow(() -> new MemberException(UNAUTHORIZED));

--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -74,17 +74,7 @@ public class DocumentQueryService {
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER))
                 .getName();
 
-        return DocumentDetailResponse
-                .builder()
-                .id(document.getId())
-                .title(document.getName())
-                .description(document.getDescription())
-                .accessType(document.getAccessType())
-                .type(document.getType())
-                .files(fileResponses)
-                .date(document.getCreatedAt().toLocalDate())
-                .uploader(uploaderName)
-                .build();
+        return DocumentDetailResponse.of(document, fileResponses, uploaderName);
     }
 
     private void validateExistMember(final Long memberId) {

--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -45,10 +45,11 @@ public class DocumentQueryService {
     }
 
     private DocumentCondensedResponse toDocumentCondensedResponse(final Document document) {
-        final Long uploaderId = memberRepository.findById(document.getUploaderId())
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER)).getId();
-        return new DocumentCondensedResponse(document.getId(), document.getName(), document.getDescription(),
-                document.getCreatedAt().toLocalDate(), uploaderId);
+        final String uploaderName = memberRepository.findById(document.getUploaderId())
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER))
+                .getName();
+
+        return DocumentCondensedResponse.of(document, uploaderName);
     }
 
     public DocumentDetailResponse getDocument(final Long documentId, final Long memberId) {

--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -70,7 +70,7 @@ public class DocumentQueryService {
             final FileResponse fileResponse = new FileResponse(file.getId(), file.getUrl());
             fileResponses.add(fileResponse);
         }
-        final String uploaderName = memberRepository.findById(document.getId())
+        final String uploaderName = memberRepository.findById(document.getUploaderId())
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER))
                 .getName();
 

--- a/src/main/java/doore/document/application/dto/response/DocumentCondensedResponse.java
+++ b/src/main/java/doore/document/application/dto/response/DocumentCondensedResponse.java
@@ -1,12 +1,24 @@
 package doore.document.application.dto.response;
 
+import doore.document.domain.Document;
 import java.time.LocalDate;
+import lombok.Builder;
 
+@Builder
 public record DocumentCondensedResponse(
         Long id,
         String title,
         String description,
         LocalDate date,
-        Long uploaderId
+        String uploaderName
 ) {
+    public static DocumentCondensedResponse of(final Document document, final String uploaderName) {
+        return DocumentCondensedResponse.builder()
+                .id(document.getId())
+                .title(document.getName())
+                .description(document.getDescription())
+                .date(document.getCreatedAt().toLocalDate())
+                .uploaderName(uploaderName)
+                .build();
+    }
 }

--- a/src/main/java/doore/document/application/dto/response/DocumentDetailResponse.java
+++ b/src/main/java/doore/document/application/dto/response/DocumentDetailResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
+@Builder
 public record DocumentDetailResponse(
         Long id,
         String title,
@@ -16,16 +17,4 @@ public record DocumentDetailResponse(
         LocalDate date,
         String uploader
 ) {
-    @Builder
-    public DocumentDetailResponse(final Long id, final String title, final String description, final DocumentAccessType accessType,
-                                  final DocumentType type, final List<FileResponse> files, final LocalDate date, final String uploader) {
-        this.id = id;
-        this.title = title;
-        this.description = description;
-        this.accessType = accessType;
-        this.type = type;
-        this.files = files;
-        this.date = date;
-        this.uploader = uploader;
-    }
 }

--- a/src/main/java/doore/document/application/dto/response/DocumentDetailResponse.java
+++ b/src/main/java/doore/document/application/dto/response/DocumentDetailResponse.java
@@ -1,5 +1,6 @@
 package doore.document.application.dto.response;
 
+import doore.document.domain.Document;
 import doore.document.domain.DocumentAccessType;
 import doore.document.domain.DocumentType;
 import java.time.LocalDate;
@@ -15,6 +16,20 @@ public record DocumentDetailResponse(
         DocumentType type,
         List<FileResponse> files,
         LocalDate date,
-        String uploader
+        String uploaderName
 ) {
+    public static DocumentDetailResponse of(final Document document, final List<FileResponse> fileResponses,
+                                            final String uploaderName) {
+        return DocumentDetailResponse
+                .builder()
+                .id(document.getId())
+                .title(document.getName())
+                .description(document.getDescription())
+                .accessType(document.getAccessType())
+                .type(document.getType())
+                .files(fileResponses)
+                .date(document.getCreatedAt().toLocalDate())
+                .uploaderName(uploaderName)
+                .build();
+    }
 }

--- a/src/test/java/doore/document/application/DocumentQueryServiceTest.java
+++ b/src/test/java/doore/document/application/DocumentQueryServiceTest.java
@@ -93,6 +93,7 @@ public class DocumentQueryServiceTest extends IntegrationTest {
         //given&when
         final List<DocumentCondensedResponse> responses =
                 documentQueryService.getAllDocument(TEAM, team.getId(), PageRequest.of(0, 4));
+        final String uploaderName = memberRepository.findById(document.getUploaderId()).orElseThrow().getName();
 
         //then
         assertAll(
@@ -100,7 +101,7 @@ public class DocumentQueryServiceTest extends IntegrationTest {
                 () -> assertEquals(responses.get(0).title(), anotherDocument.getName()),
                 () -> assertEquals(responses.get(0).description(), anotherDocument.getDescription()),
                 () -> assertEquals(responses.get(0).date(), anotherDocument.getCreatedAt().toLocalDate()),
-                () -> assertEquals(responses.get(0).uploaderId(), anotherDocument.getUploaderId())
+                () -> assertEquals(responses.get(0).uploaderName(), uploaderName)
         );
     }
 

--- a/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
@@ -97,9 +97,9 @@ public class DocumentDocsTest extends RestDocsTest {
     public void 학습자료_목록을_조회한다() throws Exception {
         //given
         final DocumentCondensedResponse documentCondensedResponse =
-                new DocumentCondensedResponse(1L, "학습자료1", "학습자료1 입니다.", LocalDate.parse("2020-02-02"), 1L);
+                new DocumentCondensedResponse(1L, "학습자료1", "학습자료1 입니다.", LocalDate.parse("2020-02-02"), "이땡떙");
         final DocumentCondensedResponse otherDocumentCondensedResponse =
-                new DocumentCondensedResponse(2L, "학습자료2", "학습자료2 입니다.", LocalDate.parse("2020-02-03"), 2L);
+                new DocumentCondensedResponse(2L, "학습자료2", "학습자료2 입니다.", LocalDate.parse("2020-02-03"), "김땡떙");
         final List<DocumentCondensedResponse> documentCondensedResponses = List.of(documentCondensedResponse, otherDocumentCondensedResponse);
         //when
         when(documentQueryService.getAllDocument(any(), any(), any(PageRequest.class)))
@@ -157,7 +157,7 @@ public class DocumentDocsTest extends RestDocsTest {
                                 numberFieldWithPath("files[].id", "첨부파일 id"),
                                 stringFieldWithPath("files[].url", "첨부파일 URL"),
                                 stringFieldWithPath("date", "학습자료 업로드 날짜"),
-                                stringFieldWithPath("uploaderName", "학습자료 업로더")
+                                stringFieldWithPath("uploaderName", "학습자료 업로더 이름")
                         )
                 ));
     }

--- a/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
@@ -157,7 +157,7 @@ public class DocumentDocsTest extends RestDocsTest {
                                 numberFieldWithPath("files[].id", "첨부파일 id"),
                                 stringFieldWithPath("files[].url", "첨부파일 URL"),
                                 stringFieldWithPath("date", "학습자료 업로드 날짜"),
-                                stringFieldWithPath("uploader", "학습자료 업로더")
+                                stringFieldWithPath("uploaderName", "학습자료 업로더")
                         )
                 ));
     }

--- a/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
@@ -135,7 +135,7 @@ public class DocumentDocsTest extends RestDocsTest {
                 .type(IMAGE)
                 .files(List.of(fileResponse))
                 .date(LocalDate.parse("2024-02-28"))
-                .uploader("김땡땡")
+                .uploaderName("김땡땡")
                 .build();
 
         //when


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #174

## 📝 작업 내용

- 학습자료 목록 조회 & 학습자료 조회의 `uploaderId`를 `uploaderName`으로 변경하였습니다
    - 학습자료 목록조회 : `uploaderId` -> `uploaderName`
    - 학습자료 조회 : `uploader `-> `uploaderName`
- 그 이외에 자잘자잘한 내용 수정 좀 있습니다!
