### PR TITLE
Fix/#207 참여자 조회시 직렬화 문제를 해결한다

### DIFF
--- a/src/main/java/doore/study/api/ParticipantController.java
+++ b/src/main/java/doore/study/api/ParticipantController.java
@@ -1,10 +1,10 @@
 package doore.study.api;
 
 import doore.member.domain.Member;
-import doore.member.domain.Participant;
 import doore.resolver.LoginMember;
 import doore.study.application.ParticipantCommandService;
 import doore.study.application.ParticipantQueryService;
+import doore.study.application.dto.response.ParticipantResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -43,9 +43,9 @@ public class ParticipantController {
     }
 
     @GetMapping("/studies/{studyId}/members") // 스터디장 & 스터디원
-    public ResponseEntity<List<Participant>> getParticipant(@PathVariable final Long studyId,
-                                                            @LoginMember final Member member) {
-        final List<Participant> participants = participantQueryService.findAllParticipants(studyId, member.getId());
+    public ResponseEntity<List<ParticipantResponse>> getParticipant(@PathVariable final Long studyId,
+                                                                    @LoginMember final Member member) {
+        final List<ParticipantResponse> participants = participantQueryService.findAllParticipants(studyId, member.getId());
         return ResponseEntity.ok(participants);
     }
 }

--- a/src/main/java/doore/study/application/ParticipantQueryService.java
+++ b/src/main/java/doore/study/application/ParticipantQueryService.java
@@ -7,10 +7,11 @@ import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 
 import doore.member.domain.Participant;
-import doore.member.domain.StudyRole;
+import doore.member.domain.StudyRoleType;
 import doore.member.domain.repository.ParticipantRepository;
 import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.exception.MemberException;
+import doore.study.application.dto.response.ParticipantResponse;
 import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
 import java.util.List;
@@ -27,16 +28,23 @@ public class ParticipantQueryService {
     private final StudyRoleRepository studyRoleRepository;
     private final ParticipantRepository participantRepository;
 
-    public List<Participant> findAllParticipants(final Long studyId, final Long memberId) {
+    public List<ParticipantResponse> findAllParticipants(final Long studyId, final Long memberId) {
         validateExistStudyLeaderAndStudyMember(studyId, memberId);
         studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
-        return participantRepository.findAllByStudyId(studyId);
+        List<Participant> participants = participantRepository.findAllByStudyId(studyId);
+        return participants.stream()
+                .map(participant -> ParticipantResponse.of(participant, getStudyRoleType(studyId, memberId))).toList();
+    }
+
+    private StudyRoleType getStudyRoleType(Long studyId, Long memberId) {
+        return studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY))
+                .getStudyRoleType();
     }
 
     private void validateExistStudyLeaderAndStudyMember(final Long studyId, final Long memberId) {
-        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!(studyRole.getStudyRoleType().equals(ROLE_스터디장) || studyRole.getStudyRoleType().equals(ROLE_스터디원))) {
+        final StudyRoleType studyRoleType = getStudyRoleType(studyId, memberId);
+        if (!(studyRoleType.equals(ROLE_스터디장) || studyRoleType.equals(ROLE_스터디원))) {
             throw new MemberException(UNAUTHORIZED);
         }
     }

--- a/src/main/java/doore/study/application/dto/response/ParticipantResponse.java
+++ b/src/main/java/doore/study/application/dto/response/ParticipantResponse.java
@@ -1,0 +1,25 @@
+package doore.study.application.dto.response;
+
+import doore.member.domain.Member;
+import doore.member.domain.Participant;
+import doore.member.domain.StudyRoleType;
+
+public record ParticipantResponse(
+        Long memberId,
+        String name,
+        String email,
+        String imageUrl,
+        StudyRoleType studyRole
+) {
+
+    public static ParticipantResponse of(final Participant participant, final StudyRoleType studyRole) {
+        Member member = participant.getMember();
+        return new ParticipantResponse(
+                member.getId(),
+                member.getName(),
+                member.getEmail(),
+                member.getImageUrl(),
+                studyRole
+        );
+    }
+}

--- a/src/test/java/doore/restdocs/docs/ParticipantApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/ParticipantApiDocsTest.java
@@ -9,9 +9,9 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import doore.member.domain.Member;
-import doore.member.domain.Participant;
+import doore.member.domain.StudyRoleType;
 import doore.restdocs.RestDocsTest;
+import doore.study.application.dto.response.ParticipantResponse;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -69,19 +69,10 @@ public class ParticipantApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("참여자를 조회한다.")
     void 참여자를_조회한다_성공() throws Exception {
-        final Member member = Member.builder()
-                .id(1L)
-                .name("팜")
-                .email("pom@gmail.com")
-                .googleId("0123456789")
-                .imageUrl(null)
-                .build();
-        final Participant participant = Participant.builder()
-                .studyId(1L)
-                .member(member)
-                .build();
+        final ParticipantResponse participantResponse = new ParticipantResponse(
+                1L, "팜", "pom@gmail.com", "imageUrl", StudyRoleType.ROLE_스터디원);
 
-        when(participantQueryService.findAllParticipants(any(), any())).thenReturn(List.of(participant));
+        when(participantQueryService.findAllParticipants(any(), any())).thenReturn(List.of(participantResponse));
 
         mockMvc.perform(RestDocumentationRequestBuilders.get("/studies/{studyId}/members", 1)
                         .header(HttpHeaders.AUTHORIZATION, accessToken))

--- a/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
+++ b/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
@@ -2,7 +2,6 @@ package doore.study.application;
 
 import static doore.member.MemberFixture.createMember;
 import static doore.member.MemberFixture.아마란스;
-import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static doore.study.StudyFixture.algorithmStudy;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,12 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
-import doore.member.domain.Participant;
 import doore.member.domain.StudyRole;
 import doore.member.domain.StudyRoleType;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.exception.MemberException;
+import doore.study.application.dto.response.ParticipantResponse;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
 import java.util.List;
@@ -69,10 +68,11 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
             participantCommandService.saveParticipant(studyId, memberId, member.getId());
 
             //then
-            final List<Participant> participants = participantQueryService.findAllParticipants(studyId, memberId);
+            final List<ParticipantResponse> participantResponses = participantQueryService.findAllParticipants(studyId,
+                    memberId);
             assertAll(
-                    () -> assertThat(participants).hasSize(1),
-                    () -> assertEquals(memberId, participants.get(0).getMember().getId())
+                    () -> assertThat(participantResponses).hasSize(1),
+                    () -> assertEquals(memberId, participantResponses.get(0).memberId())
             );
         }
 
@@ -86,11 +86,11 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
 
             //when
             participantCommandService.deleteParticipant(studyId, participant.getId(), member.getId());
-            final List<Participant> participants = participantQueryService.findAllParticipants(studyId,
+            final List<ParticipantResponse> participantResponses = participantQueryService.findAllParticipants(studyId,
                     participant.getId());
 
             //then
-            assertThat(participants).hasSize(0);
+            assertThat(participantResponses).hasSize(0);
         }
 
         @Test
@@ -104,11 +104,11 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
 
             //when
             participantCommandService.withdrawParticipant(studyId, participant.getId(), participant.getId());
-            final List<Participant> participants = participantQueryService.findAllParticipants(studyId,
+            final List<ParticipantResponse> participantResponses = participantQueryService.findAllParticipants(studyId,
                     participant.getId());
 
             //then
-            assertThat(participants).hasSize(0);
+            assertThat(participantResponses).hasSize(0);
         }
     }
 

--- a/src/test/java/doore/study/application/ParticipantQueryTest.java
+++ b/src/test/java/doore/study/application/ParticipantQueryTest.java
@@ -11,12 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
-import doore.member.domain.Participant;
 import doore.member.domain.StudyRole;
 import doore.member.domain.StudyRoleType;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.exception.MemberException;
+import doore.study.application.dto.response.ParticipantResponse;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
 import java.util.List;
@@ -64,13 +64,13 @@ public class ParticipantQueryTest extends IntegrationTest {
             participantCommandService.saveParticipant(study.getId(), member.getId(), member.getId());
 
             //when
-            final List<Participant> participants = participantQueryService.findAllParticipants(study.getId(),
+            final List<ParticipantResponse> participantResponses = participantQueryService.findAllParticipants(study.getId(),
                     member.getId());
 
             //then
             assertAll(
-                    () -> assertThat(participants).hasSize(1),
-                    () -> assertEquals(member.getId(), participants.get(0).getMember().getId())
+                    () -> assertThat(participantResponses).hasSize(1),
+                    () -> assertEquals(member.getId(), participantResponses.get(0).memberId())
             );
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #207

## 📝 작업 내용

참여자 조회시 participant 엔티티를 그대로 반환해 member가 함께 조회되며 직렬화 문제가 발생한거 같습니다. 응답을 dto로 변경하는 수정을 진행했습니다. 