### PR TITLE
Feature/#179 커리큘럼 파트의 메서드를 짧게 수정한다

### DIFF
--- a/src/main/java/doore/member/application/MemberTeamCommandService.java
+++ b/src/main/java/doore/member/application/MemberTeamCommandService.java
@@ -20,8 +20,8 @@ public class MemberTeamCommandService {
 
     public void deleteMemberTeam(final Long teamId, final Long deleteMemberId, final Long teamLeaderId) {
         validateExistTeam(teamId);
-        teamRoleValidateAccessPermission.validateTeamLeader(teamLeaderId, teamId);
-        teamRoleValidateAccessPermission.validateTeamMember(deleteMemberId, teamId);
+        teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, teamLeaderId);
+        teamRoleValidateAccessPermission.validateExistMemberTeam(teamId, deleteMemberId);
         memberTeamRepository.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
     }
 

--- a/src/main/java/doore/member/application/MemberTeamCommandService.java
+++ b/src/main/java/doore/member/application/MemberTeamCommandService.java
@@ -1,13 +1,7 @@
 package doore.member.application;
 
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_TEAM;
-import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
-
-import doore.member.domain.TeamRole;
-import doore.member.domain.TeamRoleType;
+import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.member.domain.repository.MemberTeamRepository;
-import doore.member.domain.repository.TeamRoleRepository;
-import doore.member.exception.MemberException;
 import doore.team.domain.TeamRepository;
 import doore.team.exception.TeamException;
 import doore.team.exception.TeamExceptionType;
@@ -20,31 +14,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberTeamCommandService {
     private final MemberTeamRepository memberTeamRepository;
-    private final TeamRoleRepository teamRoleRepository;
     private final TeamRepository teamRepository;
+
+    private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
 
     public void deleteMemberTeam(final Long teamId, final Long deleteMemberId, final Long teamLeaderId) {
         validateExistTeam(teamId);
-        validateTeamLeader(teamLeaderId, teamId);
-        validateTeamMember(deleteMemberId, teamId);
+        teamRoleValidateAccessPermission.validateTeamLeader(teamLeaderId, teamId);
+        teamRoleValidateAccessPermission.validateTeamMember(deleteMemberId, teamId);
         memberTeamRepository.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
-    }
-
-    private void validateTeamMember(final Long deleteMemberId, final Long teamId) {
-        TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, deleteMemberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
-        if (teamRole.getTeamRoleType().equals(TeamRoleType.ROLE_팀장)) {
-            throw new MemberException(UNAUTHORIZED);
-        }
     }
 
     private void validateExistTeam(final Long teamId) {
         teamRepository.findById(teamId).orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM));
     }
-
-    private void validateTeamLeader(Long teamLeaderId, Long teamId) {
-        teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, teamLeaderId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
-    }
-
 }

--- a/src/main/java/doore/member/application/MemberTeamQueryService.java
+++ b/src/main/java/doore/member/application/MemberTeamQueryService.java
@@ -1,15 +1,11 @@
 package doore.member.application;
 
-import static doore.member.domain.TeamRoleType.ROLE_팀원;
-import static doore.member.domain.TeamRoleType.ROLE_팀장;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_TEAM;
-import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 
+import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.member.application.dto.response.TeamMemberResponse;
 import doore.member.domain.Member;
 import doore.member.domain.MemberTeam;
-import doore.member.domain.TeamRole;
 import doore.member.domain.TeamRoleType;
 import doore.member.domain.repository.MemberTeamRepository;
 import doore.member.domain.repository.TeamRoleRepository;
@@ -29,9 +25,11 @@ public class MemberTeamQueryService {
 
     private final MemberTeamRepository memberTeamRepository;
     private final TeamRoleRepository teamRoleRepository;
+    
+    private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
 
     public List<TeamMemberResponse> findMemberTeams(final Long teamId, final String keyword, final Long memberId) {
-        validateExistTeamLeaderAndTeamMember(teamId, memberId);
+        teamRoleValidateAccessPermission.validateExistTeamLeaderAndTeamMember(teamId, memberId);
         if (keyword == null || keyword.isBlank()) {
             return findAllMemberOfTeam(teamId);
         }
@@ -66,13 +64,5 @@ public class MemberTeamQueryService {
                                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER))
                                 .getTeamRoleType()
                 ));
-    }
-
-    private void validateExistTeamLeaderAndTeamMember(final Long teamId, final Long memberId) {
-        final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
-        if (!(teamRole.getTeamRoleType().equals(ROLE_팀장) || teamRole.getTeamRoleType().equals(ROLE_팀원))){
-            throw new MemberException(UNAUTHORIZED);
-        }
     }
 }

--- a/src/main/java/doore/member/application/MemberTeamQueryService.java
+++ b/src/main/java/doore/member/application/MemberTeamQueryService.java
@@ -29,7 +29,7 @@ public class MemberTeamQueryService {
     private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
 
     public List<TeamMemberResponse> findMemberTeams(final Long teamId, final String keyword, final Long memberId) {
-        teamRoleValidateAccessPermission.validateExistTeamLeaderAndTeamMember(teamId, memberId);
+        teamRoleValidateAccessPermission.validateExistMemberTeam(teamId, memberId);
         if (keyword == null || keyword.isBlank()) {
             return findAllMemberOfTeam(teamId);
         }

--- a/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
@@ -1,0 +1,36 @@
+package doore.member.application.convenience;
+
+import static doore.member.domain.StudyRoleType.ROLE_스터디원;
+import static doore.member.domain.StudyRoleType.ROLE_스터디장;
+import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
+import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+
+import doore.member.domain.StudyRole;
+import doore.member.domain.repository.StudyRoleRepository;
+import doore.member.exception.MemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StudyRoleValidateAccessPermission {
+    private final StudyRoleRepository studyRoleRepository;
+
+    public void validateExistStudyLeader(final Long studyId, final Long memberId) {
+        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
+        if (!studyRole.getStudyRoleType().equals(ROLE_스터디장)) {
+            throw new MemberException(UNAUTHORIZED);
+        }
+    }
+
+    public void validateExistStudyLeaderAndStudyMember(final Long studyId, final Long memberId) {
+        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
+        if (!(studyRole.getStudyRoleType().equals(ROLE_스터디장) || studyRole.getStudyRoleType().equals(ROLE_스터디원))) {
+            throw new MemberException(UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
@@ -1,6 +1,5 @@
 package doore.member.application.convenience;
 
-import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.member.domain.StudyRoleType.ROLE_스터디장;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
@@ -26,11 +25,8 @@ public class StudyRoleValidateAccessPermission {
         }
     }
 
-    public void validateExistStudyLeaderAndStudyMember(final Long studyId, final Long memberId) {
-        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!(studyRole.getStudyRoleType().equals(ROLE_스터디장) || studyRole.getStudyRoleType().equals(ROLE_스터디원))) {
-            throw new MemberException(UNAUTHORIZED);
-        }
+    public void validateExistParticipant(final Long studyId, final Long memberId) {
+        studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
+                .orElseThrow(() -> new MemberException(UNAUTHORIZED));
     }
 }

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -1,6 +1,5 @@
 package doore.member.application.convenience;
 
-import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_TEAM;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
@@ -40,11 +39,8 @@ public class TeamRoleValidateAccessPermission {
         }
     }
 
-    public void validateExistTeamLeaderAndTeamMember(final Long teamId, final Long memberId) {
-        final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
-        if (!(teamRole.getTeamRoleType().equals(ROLE_팀장) || teamRole.getTeamRoleType().equals(ROLE_팀원))){
-            throw new MemberException(UNAUTHORIZED);
-        }
+    public void validateExistMemberTeam(final Long teamId, final Long memberId) {
+        teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
+                .orElseThrow(() -> new MemberException(UNAUTHORIZED));
     }
 }

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -1,0 +1,11 @@
+package doore.member.application.convenience;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TeamRoleValidateAccessPermission {
+}

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -1,5 +1,14 @@
 package doore.member.application.convenience;
 
+import static doore.member.domain.TeamRoleType.ROLE_팀원;
+import static doore.member.domain.TeamRoleType.ROLE_팀장;
+import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_TEAM;
+import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+
+import doore.member.domain.TeamRole;
+import doore.member.domain.TeamRoleType;
+import doore.member.domain.repository.TeamRoleRepository;
+import doore.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +17,26 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class TeamRoleValidateAccessPermission {
+    private final TeamRoleRepository teamRoleRepository;
+
+    public void validateTeamMember(final Long deleteMemberId, final Long teamId) {
+        TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, deleteMemberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
+        if (teamRole.getTeamRoleType().equals(TeamRoleType.ROLE_팀장)) {
+            throw new MemberException(UNAUTHORIZED);
+        }
+    }
+
+    public void validateTeamLeader(Long teamLeaderId, Long teamId) {
+        teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, teamLeaderId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
+    }
+
+    public void validateExistTeamLeaderAndTeamMember(final Long teamId, final Long memberId) {
+        final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
+        if (!(teamRole.getTeamRoleType().equals(ROLE_팀장) || teamRole.getTeamRoleType().equals(ROLE_팀원))){
+            throw new MemberException(UNAUTHORIZED);
+        }
+    }
 }

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -32,6 +32,14 @@ public class TeamRoleValidateAccessPermission {
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
     }
 
+    public void validateExistTeamLeader(final Long teamId, final Long memberId) {
+        final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
+        if (!teamRole.getTeamRoleType().equals(ROLE_팀장)) {
+            throw new MemberException(UNAUTHORIZED);
+        }
+    }
+
     public void validateExistTeamLeaderAndTeamMember(final Long teamId, final Long memberId) {
         final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -5,7 +5,6 @@ import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_I
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 
 import doore.member.domain.TeamRole;
-import doore.member.domain.TeamRoleType;
 import doore.member.domain.repository.TeamRoleRepository;
 import doore.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
@@ -17,19 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TeamRoleValidateAccessPermission {
     private final TeamRoleRepository teamRoleRepository;
-
-    public void validateTeamMember(final Long memberId, final Long teamId) {
-        TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
-        if (teamRole.getTeamRoleType().equals(TeamRoleType.ROLE_팀장)) {
-            throw new MemberException(UNAUTHORIZED);
-        }
-    }
-
-    public void validateTeamLeader(Long teamLeaderId, Long teamId) {
-        teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, teamLeaderId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
-    }
 
     public void validateExistTeamLeader(final Long teamId, final Long memberId) {
         final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -18,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class TeamRoleValidateAccessPermission {
     private final TeamRoleRepository teamRoleRepository;
 
-    public void validateTeamMember(final Long deleteMemberId, final Long teamId) {
-        TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, deleteMemberId)
+    public void validateTeamMember(final Long memberId, final Long teamId) {
+        TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
         if (teamRole.getTeamRoleType().equals(TeamRoleType.ROLE_팀장)) {
             throw new MemberException(UNAUTHORIZED);

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -63,7 +63,7 @@ public class CurriculumItemCommandService {
 
     public void checkCurriculum(final Long curriculumId, final Long participantId, final Long memberId) {
         final Study study = studyRepository.findByCurriculumItemId(curriculumId);
-        validateExistStudyLeaderAndStudyMember(study.getId(),memberId);
+        validateExistStudyLeaderAndStudyMember(study.getId(), memberId);
         final CurriculumItem curriculumItem = curriculumItemRepository.findById(curriculumId)
                 .orElseThrow(() -> new CurriculumItemException(NOT_FOUND_CURRICULUM_ITEM));
         final Participant participant = participantRepository.findById(participantId)
@@ -128,25 +128,35 @@ public class CurriculumItemCommandService {
 
     public void createCurriculumItemAndAssignToParticipants(final Long studyId,
                                                             final CurriculumItemManageDetailRequest curriculumItemRequest) {
-        final Study study = studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+        final Study study = getStudyOrThrow(studyId);
         final List<Participant> participants = participantRepository.findAllByStudyId(studyId);
-
-        final CurriculumItem createCurriculumItem = CurriculumItem.builder()
-                .name(curriculumItemRequest.name())
-                .itemOrder(curriculumItemRequest.itemOrder())
-                .study(study)
-                .build();
-        curriculumItemRepository.save(createCurriculumItem);
-
-        final List<ParticipantCurriculumItem> participantCurriculumItems = participants.stream()
-                .map(participant -> ParticipantCurriculumItem.builder()
-                        .curriculumItem(createCurriculumItem)
-                        .participantId(participant.getId())
-                        .build())
-                .toList();
+        final CurriculumItem curriculumItems = createCurriculumItem(curriculumItemRequest, study);
+        final List<ParticipantCurriculumItem> participantCurriculumItems = createParticipantCurriculumItems(
+                curriculumItems, participants);
         participantCurriculumItemRepository.saveAll(participantCurriculumItems);
     }
 
+    private Study getStudyOrThrow(final Long studyId) {
+        return studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+    }
+
+    private CurriculumItem createCurriculumItem(final CurriculumItemManageDetailRequest request, final Study study) {
+        return curriculumItemRepository.save(CurriculumItem.builder()
+                .name(request.name())
+                .itemOrder(request.itemOrder())
+                .study(study)
+                .build());
+    }
+
+    private List<ParticipantCurriculumItem> createParticipantCurriculumItems(final CurriculumItem curriculumItem,
+                                                                             final List<Participant> participants) {
+        return participants.stream()
+                .map(participant -> ParticipantCurriculumItem.builder()
+                        .curriculumItem(curriculumItem)
+                        .participantId(participant.getId())
+                        .build())
+                .toList();
+    }
 
     private void updateCurriculum(final List<CurriculumItemManageDetailRequest> curriculumItems) {
         for (final CurriculumItemManageDetailRequest requestItem : curriculumItems) {

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -1,9 +1,5 @@
 package doore.study.application;
 
-import static doore.member.domain.StudyRoleType.ROLE_스터디원;
-import static doore.member.domain.StudyRoleType.ROLE_스터디장;
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
-import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.study.exception.CurriculumItemExceptionType.CANNOT_CREATE_CURRICULUM_ITEM;
 import static doore.study.exception.CurriculumItemExceptionType.INVALID_ITEM_ORDER;
 import static doore.study.exception.CurriculumItemExceptionType.NOT_FOUND_CURRICULUM_ITEM;
@@ -13,11 +9,9 @@ import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 import doore.garden.domain.Garden;
 import doore.garden.domain.GardenType;
 import doore.garden.domain.repository.GardenRepository;
+import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.domain.Participant;
-import doore.member.domain.StudyRole;
 import doore.member.domain.repository.ParticipantRepository;
-import doore.member.domain.repository.StudyRoleRepository;
-import doore.member.exception.MemberException;
 import doore.study.application.dto.request.CurriculumItemManageDetailRequest;
 import doore.study.application.dto.request.CurriculumItemManageRequest;
 import doore.study.domain.CurriculumItem;
@@ -45,11 +39,12 @@ public class CurriculumItemCommandService {
     private final ParticipantCurriculumItemRepository participantCurriculumItemRepository;
     private final StudyRepository studyRepository;
     private final ParticipantRepository participantRepository;
-    private final StudyRoleRepository studyRoleRepository;
     private final GardenRepository gardenRepository;
 
+    private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
+
     public void manageCurriculum(final CurriculumItemManageRequest request, final Long studyId, final Long memberId) {
-        validateExistStudyLeader(studyId, memberId);
+        studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, memberId);
         final List<CurriculumItemManageDetailRequest> curriculumItems = request.curriculumItems();
         checkItemOrderDuplicate(curriculumItems);
         checkItemOrderRange(curriculumItems);
@@ -63,7 +58,7 @@ public class CurriculumItemCommandService {
 
     public void checkCurriculum(final Long curriculumId, final Long participantId, final Long memberId) {
         final Study study = studyRepository.findByCurriculumItemId(curriculumId);
-        validateExistStudyLeaderAndStudyMember(study.getId(), memberId);
+        studyRoleValidateAccessPermission.validateExistStudyLeaderAndStudyMember(study.getId(), memberId);
         final CurriculumItem curriculumItem = getCurriculumItemOrThrow(curriculumId);
         final Participant participant = getParticipantOrThrow(participantId);
         final ParticipantCurriculumItem participantCurriculumItem = getParticipantCurriculumItemOrThrow(curriculumItem,
@@ -180,22 +175,6 @@ public class CurriculumItemCommandService {
         IntStream.range(0, sortedCurriculum.size())
                 .forEach(i -> sortedCurriculum.get(i).updateItemOrder(i + 1));
         curriculumItemRepository.saveAll(sortedCurriculum);
-    }
-
-    private void validateExistStudyLeader(final Long studyId, final Long memberId) {
-        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!studyRole.getStudyRoleType().equals(ROLE_스터디장)) {
-            throw new MemberException(UNAUTHORIZED);
-        }
-    }
-
-    private void validateExistStudyLeaderAndStudyMember(final Long studyId, final Long memberId) {
-        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!(studyRole.getStudyRoleType().equals(ROLE_스터디장) || studyRole.getStudyRoleType().equals(ROLE_스터디원))) {
-            throw new MemberException(UNAUTHORIZED);
-        }
     }
 
     private Study getStudyOrThrow(final Long studyId) {

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -58,7 +58,7 @@ public class CurriculumItemCommandService {
 
     public void checkCurriculum(final Long curriculumId, final Long participantId, final Long memberId) {
         final Study study = studyRepository.findByCurriculumItemId(curriculumId);
-        studyRoleValidateAccessPermission.validateExistStudyLeaderAndStudyMember(study.getId(), memberId);
+        studyRoleValidateAccessPermission.validateExistParticipant(study.getId(), memberId);
         final CurriculumItem curriculumItem = getCurriculumItemOrThrow(curriculumId);
         final Participant participant = getParticipantOrThrow(participantId);
         final ParticipantCurriculumItem participantCurriculumItem = getParticipantCurriculumItemOrThrow(curriculumItem,

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -64,19 +64,13 @@ public class CurriculumItemCommandService {
     public void checkCurriculum(final Long curriculumId, final Long participantId, final Long memberId) {
         final Study study = studyRepository.findByCurriculumItemId(curriculumId);
         validateExistStudyLeaderAndStudyMember(study.getId(), memberId);
-        final CurriculumItem curriculumItem = curriculumItemRepository.findById(curriculumId)
-                .orElseThrow(() -> new CurriculumItemException(NOT_FOUND_CURRICULUM_ITEM));
-        final Participant participant = participantRepository.findById(participantId)
-                .orElseThrow(() -> new StudyException(NOT_FOUND_PARTICIPANT));
-        final ParticipantCurriculumItem participantCurriculumItem = participantCurriculumItemRepository.findByCurriculumItemIdAndParticipantId(
-                curriculumItem.getId(), participant.getId()).orElseThrow();
+        final CurriculumItem curriculumItem = getCurriculumItemOrThrow(curriculumId);
+        final Participant participant = getParticipantOrThrow(participantId);
+        final ParticipantCurriculumItem participantCurriculumItem = getParticipantCurriculumItemOrThrow(curriculumItem,
+                participant);
 
         participantCurriculumItem.checkCompletion();
-        if (participantCurriculumItem.getIsChecked()) {
-            createGarden(participantCurriculumItem);
-            return;
-        }
-        deleteGarden(participantCurriculumItem);
+        handleGardenBasedOnCompletionStatus(participantCurriculumItem);
     }
 
     private void createGarden(final ParticipantCurriculumItem participantCurriculumItem) {
@@ -89,6 +83,14 @@ public class CurriculumItemCommandService {
         final Long contributionId = participantCurriculumItem.getId();
         final GardenType gardenType = GardenType.getGardenTypeOf(participantCurriculumItem.getClass().getSimpleName());
         gardenRepository.deleteByContributionIdAndType(contributionId, gardenType);
+    }
+
+    private void handleGardenBasedOnCompletionStatus(final ParticipantCurriculumItem participantCurriculumItem) {
+        if (participantCurriculumItem.getIsChecked()) {
+            createGarden(participantCurriculumItem);
+            return;
+        }
+        deleteGarden(participantCurriculumItem);
     }
 
     private void checkItemOrderDuplicate(final List<CurriculumItemManageDetailRequest> curriculumItems) {
@@ -136,10 +138,6 @@ public class CurriculumItemCommandService {
         participantCurriculumItemRepository.saveAll(participantCurriculumItems);
     }
 
-    private Study getStudyOrThrow(final Long studyId) {
-        return studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
-    }
-
     private CurriculumItem createCurriculumItem(final CurriculumItemManageDetailRequest request, final Study study) {
         return curriculumItemRepository.save(CurriculumItem.builder()
                 .name(request.name())
@@ -160,8 +158,7 @@ public class CurriculumItemCommandService {
 
     private void updateCurriculum(final List<CurriculumItemManageDetailRequest> curriculumItems) {
         for (final CurriculumItemManageDetailRequest requestItem : curriculumItems) {
-            final CurriculumItem existingItem = curriculumItemRepository.findById(requestItem.id())
-                    .orElseThrow(() -> new CurriculumItemException(NOT_FOUND_CURRICULUM_ITEM));
+            final CurriculumItem existingItem = getCurriculumItemOrThrow(requestItem.id());
 
             existingItem.updateIfNameDifferent(requestItem.name());
             existingItem.updateIfItemOrderDifferent(requestItem.itemOrder());
@@ -199,5 +196,25 @@ public class CurriculumItemCommandService {
         if (!(studyRole.getStudyRoleType().equals(ROLE_스터디장) || studyRole.getStudyRoleType().equals(ROLE_스터디원))) {
             throw new MemberException(UNAUTHORIZED);
         }
+    }
+
+    private Study getStudyOrThrow(final Long studyId) {
+        return studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+    }
+
+    private CurriculumItem getCurriculumItemOrThrow(final Long curriculumId) {
+        return curriculumItemRepository.findById(curriculumId)
+                .orElseThrow(() -> new CurriculumItemException(NOT_FOUND_CURRICULUM_ITEM));
+    }
+
+    private Participant getParticipantOrThrow(final Long participantId) {
+        return participantRepository.findById(participantId)
+                .orElseThrow(() -> new StudyException(NOT_FOUND_PARTICIPANT));
+    }
+
+    private ParticipantCurriculumItem getParticipantCurriculumItemOrThrow(final CurriculumItem curriculumItem,
+                                                                          final Participant participant) {
+        return participantCurriculumItemRepository.findByCurriculumItemIdAndParticipantId(
+                curriculumItem.getId(), participant.getId()).orElseThrow();
     }
 }

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -111,7 +111,7 @@ public class CurriculumItemCommandService {
     }
 
     private void createCurriculum(final Long studyId, final List<CurriculumItemManageDetailRequest> curriculumItems) {
-        if (curriculumItemRepository.findAll().size() >= 99) {
+        if (curriculumItemRepository.count() >= 99) {
             throw new CurriculumItemException(CANNOT_CREATE_CURRICULUM_ITEM);
         }
         curriculumItems.stream()

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -1,13 +1,12 @@
 package doore.study.application;
 
 import static doore.member.domain.StudyRoleType.ROLE_스터디원;
-import static doore.member.domain.StudyRoleType.ROLE_스터디장;
-import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 
+import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.domain.Member;
 import doore.member.domain.Participant;
 import doore.member.domain.StudyRole;
@@ -30,8 +29,10 @@ public class ParticipantCommandService {
     private final MemberRepository memberRepository;
     private final StudyRoleRepository studyRoleRepository;
 
+    private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
+
     public void saveParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
-        validateExistStudyLeader(studyId, studyLeaderId);
+        studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, studyLeaderId);
         validateExistStudy(studyId);
         final Member member = validateExistMember(memberId);
         final Participant participant = Participant.builder()
@@ -53,7 +54,7 @@ public class ParticipantCommandService {
     }
 
     public void deleteParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
-        validateExistStudyLeader(studyId, studyLeaderId);
+        studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, studyLeaderId);
         validateExistStudy(studyId);
         final Member member = validateExistMember(memberId);
         participantRepository.deleteByStudyIdAndMember(studyId, member);
@@ -73,14 +74,6 @@ public class ParticipantCommandService {
 
     private Member validateExistMember(final Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
-    }
-
-    private void validateExistStudyLeader(final Long studyId, final Long memberId) {
-        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!studyRole.getStudyRoleType().equals(ROLE_스터디장)) {
-            throw new MemberException(UNAUTHORIZED);
-        }
     }
 
     private void validateExistParticipant(final Long studyId, final Long memberId) {

--- a/src/main/java/doore/study/application/ParticipantQueryService.java
+++ b/src/main/java/doore/study/application/ParticipantQueryService.java
@@ -23,7 +23,7 @@ public class ParticipantQueryService {
     private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
 
     public List<Participant> findAllParticipants(final Long studyId, final Long memberId) {
-        studyRoleValidateAccessPermission.validateExistStudyLeaderAndStudyMember(studyId, memberId);
+        studyRoleValidateAccessPermission.validateExistParticipant(studyId, memberId);
         studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
         return participantRepository.findAllByStudyId(studyId);
     }

--- a/src/main/java/doore/study/application/ParticipantQueryService.java
+++ b/src/main/java/doore/study/application/ParticipantQueryService.java
@@ -1,16 +1,10 @@
 package doore.study.application;
 
-import static doore.member.domain.StudyRoleType.ROLE_스터디원;
-import static doore.member.domain.StudyRoleType.ROLE_스터디장;
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
-import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 
+import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.domain.Participant;
-import doore.member.domain.StudyRole;
 import doore.member.domain.repository.ParticipantRepository;
-import doore.member.domain.repository.StudyRoleRepository;
-import doore.member.exception.MemberException;
 import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.StudyException;
 import java.util.List;
@@ -24,20 +18,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ParticipantQueryService {
 
     private final StudyRepository studyRepository;
-    private final StudyRoleRepository studyRoleRepository;
     private final ParticipantRepository participantRepository;
 
+    private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
+
     public List<Participant> findAllParticipants(final Long studyId, final Long memberId) {
-        validateExistStudyLeaderAndStudyMember(studyId, memberId);
+        studyRoleValidateAccessPermission.validateExistStudyLeaderAndStudyMember(studyId, memberId);
         studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
         return participantRepository.findAllByStudyId(studyId);
-    }
-
-    private void validateExistStudyLeaderAndStudyMember(final Long studyId, final Long memberId) {
-        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!(studyRole.getStudyRoleType().equals(ROLE_스터디장) || studyRole.getStudyRoleType().equals(ROLE_스터디원))) {
-            throw new MemberException(UNAUTHORIZED);
-        }
     }
 }

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -2,13 +2,12 @@ package doore.study.application;
 
 import static doore.member.domain.StudyRoleType.ROLE_스터디장;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
-import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.study.exception.StudyExceptionType.INVALID_ENDDATE;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STATUS;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 import static doore.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
+import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.domain.StudyRole;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.StudyRoleRepository;
@@ -43,6 +42,8 @@ public class StudyCommandService {
     private final ParticipantCurriculumItemRepository participantCurriculumItemRepository;
     private final ParticipantCommandService participantCommandService;
 
+    private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
+
     public void createStudy(final StudyCreateRequest request, final Long teamId, final Long memberId) {
         validateExistMember(memberId);
         validateExistTeam(teamId);
@@ -67,7 +68,7 @@ public class StudyCommandService {
     }
 
     public void deleteStudy(final Long studyId, final Long memberId) {
-        validateExistStudyLeader(studyId, memberId);
+        studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, memberId);
         validateExistStudy(studyId);
 
         final List<CurriculumItem> curriculumItems = curriculumItemRepository.findAllByStudyId(studyId);
@@ -87,19 +88,19 @@ public class StudyCommandService {
     }
 
     public void updateStudy(final StudyUpdateRequest request, final Long studyId, final Long memberId) {
-        validateExistStudyLeader(studyId, memberId);
+        studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, memberId);
         final Study study = validateExistStudy(studyId);
         study.update(request.name(), request.description(), request.startDate(), request.endDate(), request.status());
     }
 
     public void terminateStudy(final Long studyId, final Long memberId) {
-        validateExistStudyLeader(studyId, memberId);
+        studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, memberId);
         final Study study = validateExistStudy(studyId);
         study.terminate();
     }
 
     public void changeStudyStatus(final String status, final Long studyId, final Long memberId) {
-        validateExistStudyLeader(studyId, memberId);
+        studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, memberId);
         final Study study = validateExistStudy(studyId);
         try {
             final StudyStatus changedStatus = StudyStatus.valueOf(status);
@@ -119,13 +120,5 @@ public class StudyCommandService {
 
     private void validateExistMember(final Long memberId) {
         memberRepository.findById(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
-    }
-
-    private void validateExistStudyLeader(final Long studyId, final Long memberId) {
-        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        if (!studyRole.getStudyRoleType().equals(ROLE_스터디장)) {
-            throw new MemberException(UNAUTHORIZED);
-        }
     }
 }

--- a/src/main/java/doore/study/application/dto/response/ParticipantResponse.java
+++ b/src/main/java/doore/study/application/dto/response/ParticipantResponse.java
@@ -1,0 +1,25 @@
+package doore.study.application.dto.response;
+
+import doore.member.domain.Member;
+import doore.member.domain.Participant;
+import doore.member.domain.StudyRoleType;
+
+public record ParticipantResponse(
+        Long memberId,
+        String name,
+        String email,
+        String imageUrl,
+        StudyRoleType studyRole
+) {
+
+    public static ParticipantResponse of(final Participant participant, final StudyRoleType studyRole) {
+        Member member = participant.getMember();
+        return new ParticipantResponse(
+                member.getId(),
+                member.getName(),
+                member.getEmail(),
+                member.getImageUrl(),
+                studyRole
+        );
+    }
+}

--- a/src/main/java/doore/team/application/TeamCommandService.java
+++ b/src/main/java/doore/team/application/TeamCommandService.java
@@ -4,13 +4,12 @@ import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
 import static doore.member.exception.MemberExceptionType.ALREADY_JOIN_TEAM_MEMBER;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_TEAM;
-import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.team.exception.TeamExceptionType.EXPIRED_LINK;
 import static doore.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 import static doore.team.exception.TeamExceptionType.NOT_MATCH_LINK;
 
 import doore.file.application.S3ImageFileService;
+import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.member.domain.Member;
 import doore.member.domain.MemberTeam;
 import doore.member.domain.TeamRole;
@@ -54,6 +53,7 @@ public class TeamCommandService {
     private final MemberTeamRepository memberTeamRepository;
     private final S3ImageFileService s3ImageFileService;
     private final RedisUtil redisUtil;
+    private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
 
     private static final String INVITE_LINK_PREFIX = "teamId=%d";
 
@@ -87,13 +87,13 @@ public class TeamCommandService {
     }
 
     public void updateTeam(final Long teamId, final TeamUpdateRequest request, final Long memberId) {
-        validateExistTeamLeader(teamId, memberId);
+        teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, memberId);
         final Team team = validateExistTeam(teamId);
         team.update(request.name(), request.description());
     }
 
     public void updateTeamImage(final Long teamId, final MultipartFile file, final Long memberId) {
-        validateExistTeamLeader(teamId, memberId);
+        teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, memberId);
         final Team team = validateExistTeam(teamId);
 
         if (team.hasImage()) {
@@ -105,7 +105,7 @@ public class TeamCommandService {
     }
 
     public void deleteTeam(final Long teamId, final Long memberId) {
-        validateExistTeamLeader(teamId, memberId);
+        teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, memberId);
         final Team team = validateExistTeam(teamId);
         teamRepository.delete(team);
         if (team.hasImage()) {
@@ -166,14 +166,6 @@ public class TeamCommandService {
 
     private Member validateExistMember(final Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
-    }
-
-    private void validateExistTeamLeader(final Long teamId, final Long memberId) {
-        final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
-        if (!teamRole.getTeamRoleType().equals(ROLE_팀장)) {
-            throw new MemberException(UNAUTHORIZED);
-        }
     }
 
     private void duplicateCheckTeamMember(final Long teamId, final Long memberId) {

--- a/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
@@ -5,7 +5,6 @@ import static doore.member.MemberFixture.아마란스;
 import static doore.member.MemberFixture.짱구;
 import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_TEAM;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.team.TeamFixture.team;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,6 +106,6 @@ public class MemberTeamCommandServiceTest extends IntegrationTest {
         //when & then
         assertThatThrownBy(() -> {
             memberTeamCommandService.deleteMemberTeam(team.getId(), otherTeamMember.getId(), teamLeader.getId());
-        }).isInstanceOf(MemberException.class).hasMessage(NOT_FOUND_MEMBER_ROLE_IN_TEAM.errorMessage());
+        }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
     }
 }

--- a/src/test/java/doore/study/application/ParticipantQueryTest.java
+++ b/src/test/java/doore/study/application/ParticipantQueryTest.java
@@ -2,7 +2,7 @@ package doore.study.application;
 
 import static doore.member.MemberFixture.보름;
 import static doore.member.MemberFixture.아마란스;
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
+import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.study.StudyFixture.algorithmStudy;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -81,7 +81,7 @@ public class ParticipantQueryTest extends IntegrationTest {
 
             assertThatThrownBy(() -> participantQueryService.findAllParticipants(study.getId(), member.getId()))
                     .isInstanceOf(MemberException.class)
-                    .hasMessage(NOT_FOUND_MEMBER_ROLE_IN_STUDY.errorMessage());
+                    .hasMessage(UNAUTHORIZED.errorMessage());
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #179
close: #209 

## 📝 작업 내용
- `curriculumItemService`와 권한 체크 관련 코드 리팩토링 진행했습니다!
- 일단 예시로 `curriculumItemService`를 진행하였습니다 리팩토링 방향이 어떤지 봐주시면 좋을 것 같습니다!

**1. 메서드를 너무 길게 작성하지 말자. (10줄 내외로 작성)**
    - 주니어 시절엔 메서드를 짧게 작성하는 연습을 해보는 것도 좋다고 합니다
    - 초벌 코드를 작성해두고 리팩토링 하는 방향으로 가면 쉽게 작성할 수 있다고 합니다
    
**2. 권한 체크 구문은 완전 별도 클래스로 빠져나오도록 수정**
    - `StudyRole`과 `TeamRole`은 `Member`의 내용이므로 `Member`에 별도 클래스를 작성하고 그것을 참조하는 방식을 사용했습니다
    
**3. `findAll.size` 보다는 `count`를 이용하자.**
    - `findAll.size`을 이용하여 db의 행수를 알아내는 방법은 db에 락이 많이 걸린다고 합니다! 따라서 이 부분을 `count`로 수정하였습니다
    
2번 내용은 나중에 수정하려 했으나 `curriculumItem`수정할 때 필요한 부분이라서 같이 했습니다~
일단 `Member`, `Team`, `Study`를 돌며 보이는 코드만 넣어뒀습니다! 추후 작업하면서 수정하시면 될 것 같습니다!
