### PR TITLE
Feature/#211 로컬과 서버 양측에서 모두 로그인이 가능하도록 수정한다

### DIFF
--- a/src/main/java/doore/login/application/LoginService.java
+++ b/src/main/java/doore/login/application/LoginService.java
@@ -18,7 +18,7 @@ public class LoginService {
     private final JwtTokenGenerator jwtTokenGenerator;
 
     public LoginResponse loginByGoogle(final GoogleLoginRequest request) {
-        final GoogleAccountProfileResponse profile = googleClient.getGoogleAccountProfile(request.code(), request.redirect_uri());
+        final GoogleAccountProfileResponse profile = googleClient.getGoogleAccountProfile(request.code(), request.redirectUri());
         final Member member = memberCommandService.findOrCreateMemberBy(profile);
         final String token = jwtTokenGenerator.generateToken(String.valueOf(member.getId()));
         return new LoginResponse(member.getId(), token);

--- a/src/main/java/doore/login/application/LoginService.java
+++ b/src/main/java/doore/login/application/LoginService.java
@@ -18,7 +18,7 @@ public class LoginService {
     private final JwtTokenGenerator jwtTokenGenerator;
 
     public LoginResponse loginByGoogle(final GoogleLoginRequest request) {
-        final GoogleAccountProfileResponse profile = googleClient.getGoogleAccountProfile(request.code());
+        final GoogleAccountProfileResponse profile = googleClient.getGoogleAccountProfile(request.code(), request.redirect_uri());
         final Member member = memberCommandService.findOrCreateMemberBy(profile);
         final String token = jwtTokenGenerator.generateToken(String.valueOf(member.getId()));
         return new LoginResponse(member.getId(), token);

--- a/src/main/java/doore/login/application/dto/request/GoogleLoginRequest.java
+++ b/src/main/java/doore/login/application/dto/request/GoogleLoginRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record GoogleLoginRequest(
         @NotNull(message = "리다이렉션 uri은 null일 수 없습니다.")
-        String redirect_uri,
+        String redirectUri,
         @NotNull(message = "인가 코드는 null일 수 없습니다.")
         String code
 ) {

--- a/src/main/java/doore/login/application/dto/request/GoogleLoginRequest.java
+++ b/src/main/java/doore/login/application/dto/request/GoogleLoginRequest.java
@@ -3,6 +3,8 @@ package doore.login.application.dto.request;
 import jakarta.validation.constraints.NotNull;
 
 public record GoogleLoginRequest(
+        @NotNull(message = "리다이렉션 uri은 null일 수 없습니다.")
+        String redirect_uri,
         @NotNull(message = "인가 코드는 null일 수 없습니다.")
         String code
 ) {

--- a/src/main/java/doore/login/utils/GoogleClient.java
+++ b/src/main/java/doore/login/utils/GoogleClient.java
@@ -28,9 +28,6 @@ public class GoogleClient {
     @Value("${spring.security.oauth2.client.registration.google.client-secret}")
     private String clientSecret;
 
-    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
-    private String redirectUri;
-
     @Value("${spring.security.oauth2.client.registration.google.authorization-grant-type}")
     private String authorizationCode;
 
@@ -42,12 +39,12 @@ public class GoogleClient {
 
     private final RestTemplate restTemplate;
 
-    public GoogleAccountProfileResponse getGoogleAccountProfile(final String code) {
-        final String accessToken = requestGoogleAccessToken(code);
+    public GoogleAccountProfileResponse getGoogleAccountProfile(final String code, final String redirectUri) {
+        final String accessToken = requestGoogleAccessToken(code, redirectUri);
         return requestGoogleAccountProfile(accessToken);
     }
 
-    private String requestGoogleAccessToken(final String code) {
+    private String requestGoogleAccessToken(final String code,  final String redirectUri) {
         final String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
         final HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);

--- a/src/test/java/doore/login/application/LoginServiceTest.java
+++ b/src/test/java/doore/login/application/LoginServiceTest.java
@@ -34,11 +34,12 @@ class LoginServiceTest extends IntegrationTest {
         //given
         final Long expectedMemberId = member.getId();
         final String validCode = "valid_code";
-        final GoogleLoginRequest request = new GoogleLoginRequest(validCode);
+        final String redirectionUri = "redirection_uri";
+        final GoogleLoginRequest request = new GoogleLoginRequest(validCode, redirectionUri);
         final GoogleAccountProfileResponse profile = new GoogleAccountProfileResponse(
                 member.getGoogleId(), "aaa@gmail.com", true, "아마란스", "마란스", "아", "https://aaa", "ko"
         );
-        given(googleClient.getGoogleAccountProfile(validCode)).willReturn(profile);
+        given(googleClient.getGoogleAccountProfile(validCode, redirectionUri)).willReturn(profile);
 
         //when
         final Long actualMemberId = loginService.loginByGoogle(request)
@@ -55,12 +56,13 @@ class LoginServiceTest extends IntegrationTest {
         //given
         final Long beforeCount = memberRepository.count();
         final String code = "valid_code";
+        final String redirectionUri = "redirection_uri";
         final String googleId = "4321";
-        final GoogleLoginRequest request = new GoogleLoginRequest(code);
+        final GoogleLoginRequest request = new GoogleLoginRequest(code,redirectionUri);
         final GoogleAccountProfileResponse profile = new GoogleAccountProfileResponse(
                 googleId, "ppp@gmail.com", true, "프리지아", "리지아", "프", "https://aaa", "ko"
         );
-        given(googleClient.getGoogleAccountProfile(code)).willReturn(profile);
+        given(googleClient.getGoogleAccountProfile(code, redirectionUri)).willReturn(profile);
 
         //when
         final Long actual = loginService.loginByGoogle(request)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

ex) close: #211

## 📝 작업 내용

서브모듈의 redirection uri을 삭제하고 로컬과 서버 양측에서 로그인이 가능하도록 코드를 수정했습니다.
