### PR TITLE
Feature/#215 초대 링크 발급은 팀장만 가능하도록 한다

### DIFF
--- a/src/main/java/doore/team/api/TeamController.java
+++ b/src/main/java/doore/team/api/TeamController.java
@@ -75,11 +75,10 @@ public class TeamController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/{teamId}/invite-code")
-    public ResponseEntity<TeamInviteCodeResponse> generateTeamInviteCode(
-            @PathVariable final Long teamId
-    ) {
-        final TeamInviteCodeResponse teamInviteCodeResponse = teamCommandService.generateTeamInviteCode(teamId);
+    @PostMapping("/{teamId}/invite-code") // 팀장
+    public ResponseEntity<TeamInviteCodeResponse> generateTeamInviteCode(@PathVariable final Long teamId,
+                                                                         @LoginMember Member member) {
+        final TeamInviteCodeResponse teamInviteCodeResponse = teamCommandService.generateTeamInviteCode(teamId, member.getId());
         return ResponseEntity.ok(teamInviteCodeResponse);
     }
 

--- a/src/main/java/doore/team/api/TeamController.java
+++ b/src/main/java/doore/team/api/TeamController.java
@@ -77,7 +77,7 @@ public class TeamController {
 
     @PostMapping("/{teamId}/invite-code") // 팀장
     public ResponseEntity<TeamInviteCodeResponse> generateTeamInviteCode(@PathVariable final Long teamId,
-                                                                         @LoginMember Member member) {
+                                                                         @LoginMember final Member member) {
         final TeamInviteCodeResponse teamInviteCodeResponse = teamCommandService.generateTeamInviteCode(teamId, member.getId());
         return ResponseEntity.ok(teamInviteCodeResponse);
     }

--- a/src/main/java/doore/team/application/TeamCommandService.java
+++ b/src/main/java/doore/team/application/TeamCommandService.java
@@ -113,8 +113,9 @@ public class TeamCommandService {
                 .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
     }
 
-    public TeamInviteCodeResponse generateTeamInviteCode(final Long teamId) {
+    public TeamInviteCodeResponse generateTeamInviteCode(final Long teamId, final Long memberId) {
         validateExistTeam(teamId);
+        teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, memberId);
 
         final Optional<String> link = redisUtil.getData(INVITE_LINK_PREFIX.formatted(teamId), String.class);
         if (link.isEmpty()) {

--- a/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
@@ -168,7 +168,7 @@ public class TeamApiDocsTest extends RestDocsTest {
         final TeamInviteCodeResponse response = new TeamInviteCodeResponse("asdf");
 
         // when
-        when(teamCommandService.generateTeamInviteCode(eq(teamId))).thenReturn(response);
+        when(teamCommandService.generateTeamInviteCode(eq(teamId), any())).thenReturn(response);
 
         // then
         final PathParametersSnippet pathParameters = pathParameters(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #125

## 📝 작업 내용

- 초대 링크 발급에 대한 권한이 설정되어 있지 않은 부분에 대해 `팀장`만 발급 가능하도록 변경하였습니다!


