### PR TITLE
Feature/#216 팀원이 아닌 사람이 스터디 개설이 가능한 문제 해결

### DIFF
--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -34,7 +34,7 @@ public class StudyController {
     private final StudyCommandService studyCommandService;
     private final StudyQueryService studyQueryService;
 
-    @PostMapping("/teams/{teamId}/studies") //회원
+    @PostMapping("/teams/{teamId}/studies") // 팀원
     public ResponseEntity<Void> createStudy(@Valid @RequestBody final StudyCreateRequest studyRequest,
                                             @PathVariable final Long teamId, @LoginMember final Member member) {
         studyCommandService.createStudy(studyRequest, teamId, member.getId());

--- a/src/main/java/doore/study/api/StudyController.java
+++ b/src/main/java/doore/study/api/StudyController.java
@@ -34,7 +34,7 @@ public class StudyController {
     private final StudyCommandService studyCommandService;
     private final StudyQueryService studyQueryService;
 
-    @PostMapping("/teams/{teamId}/studies") // 팀원
+    @PostMapping("/teams/{teamId}/studies") // 팀원 & 팀장
     public ResponseEntity<Void> createStudy(@Valid @RequestBody final StudyCreateRequest studyRequest,
                                             @PathVariable final Long teamId, @LoginMember final Member member) {
         studyCommandService.createStudy(studyRequest, teamId, member.getId());

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -8,6 +8,7 @@ import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 import static doore.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
+import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.member.domain.Participant;
 import doore.member.domain.StudyRole;
 import doore.member.domain.repository.MemberRepository;
@@ -45,11 +46,14 @@ public class StudyCommandService {
     private final ParticipantRepository participantRepository;
     private final ParticipantCommandService participantCommandService;
 
+    private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
     private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
 
     public void createStudy(final StudyCreateRequest request, final Long teamId, final Long memberId) {
         validateExistMember(memberId);
         validateExistTeam(teamId);
+        teamRoleValidateAccessPermission.validateExistMemberTeam(teamId, memberId);
+
         checkEndDateValid(request.startDate(), request.endDate());
         final Study study = studyRepository.save(request.toStudy(teamId));
         studyRoleRepository.save(StudyRole.builder()

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -2,6 +2,7 @@ package doore.study.api;
 
 import static doore.member.MemberFixture.createMember;
 import static doore.member.domain.StudyRoleType.ROLE_스터디장;
+import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.study.StudyFixture.createStudy;
 import static doore.team.TeamFixture.createTeam;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,7 +10,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
+import doore.member.domain.TeamRole;
 import doore.member.domain.repository.StudyRoleRepository;
+import doore.member.domain.repository.TeamRoleRepository;
 import doore.study.application.dto.request.StudyCreateRequest;
 import doore.study.domain.Study;
 import doore.team.domain.Team;
@@ -25,18 +28,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class StudyControllerTest extends IntegrationTest {
     @Autowired
     private StudyRoleRepository studyRoleRepository;
+    @Autowired
+    private TeamRoleRepository teamRoleRepository;
 
     private Member member;
     private Study study;
     private Team team;
     private String token;
     private StudyRole studyRole;
+    private TeamRole teamRole;
 
     @BeforeEach
     void setUp() {
         member = createMember();
         study = createStudy();
         team = createTeam();
+        teamRole = teamRoleRepository.save(TeamRole.builder()
+                .teamId(team.getId())
+                .teamRoleType(ROLE_팀원)
+                .memberId(member.getId())
+                .build());
         studyRole = studyRoleRepository.save(StudyRole.builder()
                 .studyId(study.getId())
                 .studyRoleType(ROLE_스터디장)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #216

## 📝 작업 내용

- 스터디 생성 권한이 `회원`에서 `팀장` 또는 `팀원`으로 변경되었습니다!
+) 이슈 번호가 216번인데 실수로 branch를 126번으로 만들었습니다,, PR 제목 수정해두었습니다
