### PR TITLE
Fix/#219 커리큘럼 생성 및 수정 문제를 해결한다

### DIFF
--- a/src/main/java/doore/garden/application/convenience/GardenConvenience.java
+++ b/src/main/java/doore/garden/application/convenience/GardenConvenience.java
@@ -1,0 +1,28 @@
+package doore.garden.application.convenience;
+
+import doore.garden.domain.Garden;
+import doore.garden.domain.GardenType;
+import doore.garden.domain.repository.GardenRepository;
+import doore.study.domain.ParticipantCurriculumItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GardenConvenience {
+    private final GardenRepository gardenRepository;
+
+    public void createCurriculumGarden(final ParticipantCurriculumItem participantCurriculumItem) {
+        final Garden garden = GardenType.getSupplierOf(participantCurriculumItem.getClass().getSimpleName())
+                .of(participantCurriculumItem);
+        gardenRepository.save(garden);
+    }
+
+    public void deleteCurriculumGarden(final ParticipantCurriculumItem participantCurriculumItem) {
+        final Long contributionId = participantCurriculumItem.getId();
+        final GardenType gardenType = GardenType.getGardenTypeOf(participantCurriculumItem.getClass().getSimpleName());
+        gardenRepository.deleteByContributionIdAndType(contributionId, gardenType);
+    }
+}

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -47,7 +47,6 @@ public class CurriculumItemCommandService {
         studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, memberId);
         final List<CurriculumItemManageDetailRequest> curriculumItems = request.curriculumItems();
         checkItemOrderDuplicate(curriculumItems);
-        checkItemOrderRange(curriculumItems);
         createCurriculum(studyId, curriculumItems);
         updateCurriculum(curriculumItems);
 
@@ -95,16 +94,6 @@ public class CurriculumItemCommandService {
                 .map(CurriculumItemManageDetailRequest::itemOrder)
                 .forEach(itemOrder -> {
                     if (!uniqueItemOrders.add(itemOrder)) {
-                        throw new CurriculumItemException(INVALID_ITEM_ORDER);
-                    }
-                });
-    }
-
-    private void checkItemOrderRange(final List<CurriculumItemManageDetailRequest> curriculumItems) {
-        curriculumItems.stream()
-                .mapToInt(CurriculumItemManageDetailRequest::itemOrder)
-                .forEach(itemOrder -> {
-                    if (itemOrder < Integer.MIN_VALUE || itemOrder > Integer.MAX_VALUE) {
                         throw new CurriculumItemException(INVALID_ITEM_ORDER);
                     }
                 });

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -46,9 +46,12 @@ public class CurriculumItemCommandService {
     public void manageCurriculum(final CurriculumItemManageRequest request, final Long studyId, final Long memberId) {
         studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, memberId);
         final List<CurriculumItemManageDetailRequest> curriculumItems = request.curriculumItems();
+        if (curriculumItems.size() >= 99) {
+            throw new CurriculumItemException(CANNOT_CREATE_CURRICULUM_ITEM);
+        }
+
         checkItemOrderDuplicate(curriculumItems);
-        createCurriculum(studyId, curriculumItems);
-        updateCurriculum(curriculumItems);
+        curriculumItems.forEach(item -> createOrUpdateCurriculum(studyId, item));
 
         final List<CurriculumItemManageDetailRequest> deletedCurriculumItems = request.deletedCurriculumItems();
         deleteCurriculum(deletedCurriculumItems);
@@ -99,21 +102,18 @@ public class CurriculumItemCommandService {
                 });
     }
 
-    private void createCurriculum(final Long studyId, final List<CurriculumItemManageDetailRequest> curriculumItems) {
-        if (curriculumItemRepository.countByStudyId(studyId) >= 99) {
-            throw new CurriculumItemException(CANNOT_CREATE_CURRICULUM_ITEM);
+    private void createOrUpdateCurriculum(final Long studyId, final CurriculumItemManageDetailRequest curriculumItem) {
+        if (curriculumItem.id() == null) {
+            createCurriculum(studyId, curriculumItem); // 생성
         }
-        curriculumItems.stream()
-                .filter(curriculumItem -> !isExistsCurriculumItem(curriculumItem.id()))
-                .forEach(curriculumItem -> createCurriculumItemAndAssignToParticipants(studyId, curriculumItem));
+        updateCurriculum(curriculumItem); //수정
     }
 
     private boolean isExistsCurriculumItem(final Long curriculumItemId) {
         return curriculumItemRepository.existsById(curriculumItemId);
     }
 
-    public void createCurriculumItemAndAssignToParticipants(final Long studyId,
-                                                            final CurriculumItemManageDetailRequest curriculumItemRequest) {
+    public void createCurriculum(final Long studyId, final CurriculumItemManageDetailRequest curriculumItemRequest) {
         final Study study = getStudyOrThrow(studyId);
         final List<Participant> participants = participantRepository.findAllByStudyId(studyId);
         final CurriculumItem curriculumItems = createCurriculumItem(curriculumItemRequest, study);
@@ -140,13 +140,10 @@ public class CurriculumItemCommandService {
                 .toList();
     }
 
-    private void updateCurriculum(final List<CurriculumItemManageDetailRequest> curriculumItems) {
-        for (final CurriculumItemManageDetailRequest requestItem : curriculumItems) {
-            final CurriculumItem existingItem = getCurriculumItemOrThrow(requestItem.id());
-
-            existingItem.updateIfNameDifferent(requestItem.name());
-            existingItem.updateIfItemOrderDifferent(requestItem.itemOrder());
-        }
+    private void updateCurriculum(final CurriculumItemManageDetailRequest curriculumItem) {
+        final CurriculumItem existingItem = getCurriculumItemOrThrow(curriculumItem.id());
+        existingItem.updateIfNameDifferent(curriculumItem.name());
+        existingItem.updateIfItemOrderDifferent(curriculumItem.itemOrder());
     }
 
     private void deleteCurriculum(final List<CurriculumItemManageDetailRequest> deletedCurriculumItems) {

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -4,7 +4,6 @@ import static doore.study.exception.CurriculumItemExceptionType.CANNOT_CREATE_CU
 import static doore.study.exception.CurriculumItemExceptionType.INVALID_ITEM_ORDER;
 import static doore.study.exception.CurriculumItemExceptionType.NOT_FOUND_CURRICULUM_ITEM;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_PARTICIPANT;
-import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
 
 import doore.garden.domain.Garden;
 import doore.garden.domain.GardenType;
@@ -12,6 +11,8 @@ import doore.garden.domain.repository.GardenRepository;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.domain.Participant;
 import doore.member.domain.repository.ParticipantRepository;
+import doore.study.application.convenience.StudyAuthorization;
+import doore.study.application.convenience.StudyConvenience;
 import doore.study.application.dto.request.CurriculumItemManageDetailRequest;
 import doore.study.application.dto.request.CurriculumItemManageRequest;
 import doore.study.domain.CurriculumItem;
@@ -19,7 +20,6 @@ import doore.study.domain.ParticipantCurriculumItem;
 import doore.study.domain.Study;
 import doore.study.domain.repository.CurriculumItemRepository;
 import doore.study.domain.repository.ParticipantCurriculumItemRepository;
-import doore.study.domain.repository.StudyRepository;
 import doore.study.exception.CurriculumItemException;
 import doore.study.exception.StudyException;
 import java.util.HashSet;
@@ -37,7 +37,8 @@ public class CurriculumItemCommandService {
 
     private final CurriculumItemRepository curriculumItemRepository;
     private final ParticipantCurriculumItemRepository participantCurriculumItemRepository;
-    private final StudyRepository studyRepository;
+    private final StudyConvenience studyConvenience;
+    private final StudyAuthorization studyAuthorization;
     private final ParticipantRepository participantRepository;
     private final GardenRepository gardenRepository;
 
@@ -59,7 +60,7 @@ public class CurriculumItemCommandService {
     }
 
     public void checkCurriculum(final Long curriculumId, final Long participantId, final Long memberId) {
-        final Study study = studyRepository.findByCurriculumItemId(curriculumId);
+        final Study study = studyConvenience.findByCurriculumItemId(curriculumId);
         studyRoleValidateAccessPermission.validateExistParticipant(study.getId(), memberId);
         final CurriculumItem curriculumItem = getCurriculumItemOrThrow(curriculumId);
         final Participant participant = getParticipantOrThrow(participantId);
@@ -110,7 +111,7 @@ public class CurriculumItemCommandService {
     }
 
     public void createCurriculum(final Long studyId, final CurriculumItemManageDetailRequest curriculumItemRequest) {
-        final Study study = getStudyOrThrow(studyId);
+        final Study study = studyAuthorization.getStudyOrThrow(studyId);
         final CurriculumItem curriculumItem = CurriculumItem.builder()
                 .name(curriculumItemRequest.name())
                 .itemOrder(curriculumItemRequest.itemOrder())
@@ -153,10 +154,6 @@ public class CurriculumItemCommandService {
         IntStream.range(0, sortedCurriculum.size())
                 .forEach(i -> sortedCurriculum.get(i).updateItemOrder(i + 1));
         curriculumItemRepository.saveAll(sortedCurriculum);
-    }
-
-    private Study getStudyOrThrow(final Long studyId) {
-        return studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
     }
 
     private CurriculumItem getCurriculumItemOrThrow(final Long curriculumId) {

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -109,35 +109,27 @@ public class CurriculumItemCommandService {
         updateCurriculum(curriculumItem); //수정
     }
 
-    private boolean isExistsCurriculumItem(final Long curriculumItemId) {
-        return curriculumItemRepository.existsById(curriculumItemId);
-    }
-
     public void createCurriculum(final Long studyId, final CurriculumItemManageDetailRequest curriculumItemRequest) {
         final Study study = getStudyOrThrow(studyId);
+        final CurriculumItem curriculumItem = CurriculumItem.builder()
+                .name(curriculumItemRequest.name())
+                .itemOrder(curriculumItemRequest.itemOrder())
+                .study(study)
+                .build();
+        curriculumItemRepository.save(curriculumItem);
+
         final List<Participant> participants = participantRepository.findAllByStudyId(studyId);
-        final CurriculumItem curriculumItems = createCurriculumItem(curriculumItemRequest, study);
-        final List<ParticipantCurriculumItem> participantCurriculumItems = createParticipantCurriculumItems(
-                curriculumItems, participants);
+        final List<ParticipantCurriculumItem> participantCurriculumItems = participants.stream()
+                .map(participant -> createParticipantCurriculumItems(curriculumItem, participant)).toList();
         participantCurriculumItemRepository.saveAll(participantCurriculumItems);
     }
 
-    private CurriculumItem createCurriculumItem(final CurriculumItemManageDetailRequest request, final Study study) {
-        return curriculumItemRepository.save(CurriculumItem.builder()
-                .name(request.name())
-                .itemOrder(request.itemOrder())
-                .study(study)
-                .build());
-    }
-
-    private List<ParticipantCurriculumItem> createParticipantCurriculumItems(final CurriculumItem curriculumItem,
-                                                                             final List<Participant> participants) {
-        return participants.stream()
-                .map(participant -> ParticipantCurriculumItem.builder()
-                        .curriculumItem(curriculumItem)
-                        .participantId(participant.getId())
-                        .build())
-                .toList();
+    private ParticipantCurriculumItem createParticipantCurriculumItems(final CurriculumItem curriculumItem,
+                                                                       final Participant participant) {
+        return ParticipantCurriculumItem.builder()
+                .curriculumItem(curriculumItem)
+                .participantId(participant.getId())
+                .build();
     }
 
     private void updateCurriculum(final CurriculumItemManageDetailRequest curriculumItem) {

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -5,9 +5,7 @@ import static doore.study.exception.CurriculumItemExceptionType.INVALID_ITEM_ORD
 import static doore.study.exception.CurriculumItemExceptionType.NOT_FOUND_CURRICULUM_ITEM;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_PARTICIPANT;
 
-import doore.garden.domain.Garden;
-import doore.garden.domain.GardenType;
-import doore.garden.domain.repository.GardenRepository;
+import doore.garden.application.convenience.GardenConvenience;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.domain.Participant;
 import doore.member.domain.repository.ParticipantRepository;
@@ -36,12 +34,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class CurriculumItemCommandService {
 
     private final CurriculumItemRepository curriculumItemRepository;
+    private final ParticipantRepository participantRepository;
     private final ParticipantCurriculumItemRepository participantCurriculumItemRepository;
     private final StudyConvenience studyConvenience;
     private final StudyAuthorization studyAuthorization;
-    private final ParticipantRepository participantRepository;
-    private final GardenRepository gardenRepository;
-
+    private final GardenConvenience gardenConvenience;
     private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
 
     public void manageCurriculum(final CurriculumItemManageRequest request, final Long studyId, final Long memberId) {
@@ -71,24 +68,12 @@ public class CurriculumItemCommandService {
         handleGardenBasedOnCompletionStatus(participantCurriculumItem);
     }
 
-    private void createGarden(final ParticipantCurriculumItem participantCurriculumItem) {
-        final Garden garden = GardenType.getSupplierOf(participantCurriculumItem.getClass().getSimpleName())
-                .of(participantCurriculumItem);
-        gardenRepository.save(garden);
-    }
-
-    private void deleteGarden(final ParticipantCurriculumItem participantCurriculumItem) {
-        final Long contributionId = participantCurriculumItem.getId();
-        final GardenType gardenType = GardenType.getGardenTypeOf(participantCurriculumItem.getClass().getSimpleName());
-        gardenRepository.deleteByContributionIdAndType(contributionId, gardenType);
-    }
-
     private void handleGardenBasedOnCompletionStatus(final ParticipantCurriculumItem participantCurriculumItem) {
         if (participantCurriculumItem.getIsChecked()) {
-            createGarden(participantCurriculumItem);
+            gardenConvenience.createCurriculumGarden(participantCurriculumItem);
             return;
         }
-        deleteGarden(participantCurriculumItem);
+        gardenConvenience.deleteCurriculumGarden(participantCurriculumItem);
     }
 
     private void checkItemOrderDuplicate(final List<CurriculumItemManageDetailRequest> curriculumItems) {

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -106,6 +106,7 @@ public class CurriculumItemCommandService {
     private void createOrUpdateCurriculum(final Long studyId, final CurriculumItemManageDetailRequest curriculumItem) {
         if (curriculumItem.id() == null) {
             createCurriculum(studyId, curriculumItem); // 생성
+            return;
         }
         updateCurriculum(curriculumItem); //수정
     }
@@ -135,8 +136,9 @@ public class CurriculumItemCommandService {
 
     private void updateCurriculum(final CurriculumItemManageDetailRequest curriculumItem) {
         final CurriculumItem existingItem = getCurriculumItemOrThrow(curriculumItem.id());
-        existingItem.updateIfNameDifferent(curriculumItem.name());
-        existingItem.updateIfItemOrderDifferent(curriculumItem.itemOrder());
+        if (existingItem.changed(curriculumItem.name(), curriculumItem.itemOrder())) {
+            existingItem.update(curriculumItem.name(), curriculumItem.itemOrder());
+        }
     }
 
     private void deleteCurriculum(final List<CurriculumItemManageDetailRequest> deletedCurriculumItems) {

--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -111,7 +111,7 @@ public class CurriculumItemCommandService {
     }
 
     private void createCurriculum(final Long studyId, final List<CurriculumItemManageDetailRequest> curriculumItems) {
-        if (curriculumItemRepository.count() >= 99) {
+        if (curriculumItemRepository.countByStudyId(studyId) >= 99) {
             throw new CurriculumItemException(CANNOT_CREATE_CURRICULUM_ITEM);
         }
         curriculumItems.stream()

--- a/src/main/java/doore/study/application/convenience/StudyAuthorization.java
+++ b/src/main/java/doore/study/application/convenience/StudyAuthorization.java
@@ -1,0 +1,25 @@
+package doore.study.application.convenience;
+
+import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
+
+import doore.study.domain.Study;
+import doore.study.domain.repository.StudyRepository;
+import doore.study.exception.StudyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyAuthorization {
+    private final StudyRepository studyRepository;
+
+    public void validateExistStudy(Long studyId) {
+        studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+    }
+
+    public Study getStudyOrThrow(final Long studyId) {
+        return studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
+    }
+}

--- a/src/main/java/doore/study/application/convenience/StudyConvenience.java
+++ b/src/main/java/doore/study/application/convenience/StudyConvenience.java
@@ -1,0 +1,18 @@
+package doore.study.application.convenience;
+
+import doore.study.domain.Study;
+import doore.study.domain.repository.StudyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StudyConvenience {
+    private final StudyRepository studyRepository;
+
+    public Study findByCurriculumItemId(Long curriculumId) {
+        return studyRepository.findByCurriculumItemId(curriculumId);
+    }
+}

--- a/src/main/java/doore/study/application/dto/request/CurriculumItemManageDetailRequest.java
+++ b/src/main/java/doore/study/application/dto/request/CurriculumItemManageDetailRequest.java
@@ -1,13 +1,15 @@
 package doore.study.application.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record CurriculumItemManageDetailRequest(
-        @NotNull(message = "id를 입력해주세요.")
         Long id,
         @NotNull(message = "아이템 순서를 입력해주세요.")
+        @Min(0) @Max(99)
         Integer itemOrder,
         @NotNull(message = "이름을 입력해주세요.")
         String name

--- a/src/main/java/doore/study/domain/CurriculumItem.java
+++ b/src/main/java/doore/study/domain/CurriculumItem.java
@@ -32,6 +32,8 @@ public class CurriculumItem extends BaseEntity {
     @Column(nullable = false)
     private Integer itemOrder;
 
+    // 직접 커리큘럼을 삭제한 경우에는 하드 딜리트한다.
+    // 스터디가 삭제된 경우에 소프트 딜리트한다.
     @Column(nullable = false)
     private Boolean isDeleted;
 
@@ -63,19 +65,16 @@ public class CurriculumItem extends BaseEntity {
         this.study = study;
     }
 
-    public void updateIfNameDifferent(String name) {
-        if (!this.name.equals(name)) {
-            this.updateName(name);
-        }
-    }
-
-    public void updateIfItemOrderDifferent(Integer itemOrder) {
-        if (!this.itemOrder.equals(itemOrder)) {
-            this.updateItemOrder(itemOrder);
-        }
-    }
-
     public void delete() {
         this.isDeleted = true;
+    }
+
+    public boolean changed(String name, Integer itemOrder) {
+        return !this.name.equals(name) || !this.itemOrder.equals(itemOrder);
+    }
+
+    public void update(String name, Integer itemOrder) {
+        this.name = name;
+        this.itemOrder = itemOrder;
     }
 }

--- a/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
+++ b/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
@@ -14,4 +14,6 @@ public interface CurriculumItemRepository extends JpaRepository<CurriculumItem, 
 
     @Query("SELECT ci.id FROM CurriculumItem ci WHERE ci.study.id = :studyId")
     List<Long> findIdsByStudyId(Long studyId);
+
+    Long countByStudyId(Long studyId);
 }

--- a/src/main/java/doore/study/domain/repository/ParticipantCurriculumItemRepository.java
+++ b/src/main/java/doore/study/domain/repository/ParticipantCurriculumItemRepository.java
@@ -10,11 +10,9 @@ public interface ParticipantCurriculumItemRepository extends JpaRepository<Parti
     Optional<ParticipantCurriculumItem> findByCurriculumItemIdAndParticipantId(Long curriculumId, Long participantId);
 
     @Query("select pc from ParticipantCurriculumItem pc "
-            + "inner join CurriculumItem c on c = pc.curriculumItem "
             + "inner join Participant p on pc.participantId = p.id "
-            + "inner join Member m on p.member.id = m.id "
-            + "where m.id = :memberId "
-            + "and c.study.id = :studyId ")
+            + "where p.member.id = :memberId "
+            + "and pc.curriculumItem.study.id = :studyId ")
     List<ParticipantCurriculumItem> findAllByStudyIdAndMemberId(Long studyId, Long memberId);
 
     List<ParticipantCurriculumItem> findAllByCurriculumItemId(Long curriculumId);

--- a/src/test/java/doore/restdocs/docs/CurriculumItemApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/CurriculumItemApiDocsTest.java
@@ -85,7 +85,7 @@ public class CurriculumItemApiDocsTest extends RestDocsTest {
                                 parameterWithName("studyId").description("스터디 id")),
                         requestFields(
                                 fieldWithPath("curriculumItems").description("커리큘럼 아이템 리스트"),
-                                fieldWithPath("curriculumItems[].id").description("커리큘럼 아이템 ID"),
+                                fieldWithPath("curriculumItems[].id").description("커리큘럼 아이템 ID (새로 생성된 경우 null)"),
                                 fieldWithPath("curriculumItems[].itemOrder").description("커리큘럼 아이템 순서"),
                                 fieldWithPath("curriculumItems[].name").description("커리큘럼 아이템 이름"),
                                 fieldWithPath("deletedCurriculumItems").description("삭제된 커리큘럼 아이템 리스트"),

--- a/src/test/java/doore/study/application/CurriculumItemQueryServiceTest.java
+++ b/src/test/java/doore/study/application/CurriculumItemQueryServiceTest.java
@@ -1,0 +1,139 @@
+package doore.study.application;
+
+import static doore.member.MemberFixture.미나;
+import static doore.study.StudyFixture.algorithmStudy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import doore.helper.IntegrationTest;
+import doore.member.domain.Member;
+import doore.member.domain.Participant;
+import doore.member.domain.StudyRole;
+import doore.member.domain.StudyRoleType;
+import doore.member.domain.repository.MemberRepository;
+import doore.member.domain.repository.ParticipantRepository;
+import doore.member.domain.repository.StudyRoleRepository;
+import doore.study.application.dto.request.CurriculumItemManageDetailRequest;
+import doore.study.application.dto.request.CurriculumItemManageRequest;
+import doore.study.application.dto.response.PersonalCurriculumItemResponse;
+import doore.study.domain.CurriculumItem;
+import doore.study.domain.ParticipantCurriculumItem;
+import doore.study.domain.Study;
+import doore.study.domain.repository.CurriculumItemRepository;
+import doore.study.domain.repository.ParticipantCurriculumItemRepository;
+import doore.study.domain.repository.StudyRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CurriculumItemQueryServiceTest  extends IntegrationTest {
+    @Autowired
+    private CurriculumItemCommandService curriculumItemCommandService;
+    @Autowired
+    private CurriculumItemQueryService curriculumItemQueryService;
+    @Autowired
+    private CurriculumItemRepository curriculumItemRepository;
+    @Autowired
+    private StudyRepository studyRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ParticipantRepository participantRepository;
+    @Autowired
+    private ParticipantCurriculumItemRepository participantCurriculumItemRepository;
+    @Autowired
+    private StudyRoleRepository studyRoleRepository;
+
+    private Study study;
+    private CurriculumItem curriculumItem1;
+    private CurriculumItem curriculumItem2;
+    private CurriculumItem curriculumItem3;
+    private CurriculumItemManageRequest request;
+    private Long memberId;
+    private Member member;
+
+
+    @BeforeEach
+    void setUp() {
+        study = studyRepository.save(algorithmStudy());
+
+        curriculumItem1 = CurriculumItem.builder().id(1L).itemOrder(1).name("Spring Study").study(study).build();
+        curriculumItemRepository.save(curriculumItem1);
+        curriculumItem2 = CurriculumItem.builder().id(2L).itemOrder(2).name("CS Study").study(study).build();
+        curriculumItemRepository.save(curriculumItem2);
+        curriculumItem3 = CurriculumItem.builder().id(3L).itemOrder(3).name("Infra Study").study(study).build();
+        curriculumItemRepository.save(curriculumItem3);
+
+        request = CurriculumItemManageRequest.builder()
+                .curriculumItems(getCurriculumItems())
+                .deletedCurriculumItems(getDeletedCurriculumItems())
+                .build();
+        member = memberRepository.save(미나());
+        memberId = member.getId();
+
+        StudyRole studyRole = studyRoleRepository.save(StudyRole.builder()
+                .studyRoleType(StudyRoleType.ROLE_스터디장)
+                .studyId(study.getId())
+                .memberId(memberId)
+                .build());
+    }
+
+
+    private List<CurriculumItemManageDetailRequest> getCurriculumItems() {
+        final List<CurriculumItemManageDetailRequest> curriculumItems = new ArrayList<>();
+        curriculumItems.add(
+                CurriculumItemManageDetailRequest.builder().id(1L).itemOrder(1).name("Change Spring Study").build());
+        curriculumItems.add(CurriculumItemManageDetailRequest.builder().id(2L).itemOrder(4).name("CS Study").build());
+        curriculumItems.add(
+                CurriculumItemManageDetailRequest.builder().id(3L).itemOrder(2).name("Infra Study").build());
+        curriculumItems.add(
+                CurriculumItemManageDetailRequest.builder().itemOrder(3).name("Algorithm Study").build());
+        return curriculumItems;
+    }
+
+    private List<CurriculumItemManageDetailRequest> getDeletedCurriculumItems() {
+        final List<CurriculumItemManageDetailRequest> deletedCurriculumItems = new ArrayList<>();
+        deletedCurriculumItems.add(
+                CurriculumItemManageDetailRequest.builder().id(3L).itemOrder(2).name("Infra Study").build());
+        return deletedCurriculumItems;
+    }
+
+    @Test
+    @DisplayName("[성공] 정상적으로 수정된 커리큘럼을 조회할 수 있다.")
+    public void getMyCurriculum_정상적으로_수정된_커리큘럼을_수정할_수_있다() throws Exception {
+        //given
+        Participant participant = Participant.builder().member(member).studyId(study.getId()).build();
+        participantRepository.save(participant);
+
+        ParticipantCurriculumItem participantCurriculumItem1 = ParticipantCurriculumItem.builder()
+                .participantId(participant.getId())
+                .curriculumItem(curriculumItem1)
+                .build();
+        ParticipantCurriculumItem participantCurriculumItem2 = ParticipantCurriculumItem.builder()
+                .participantId(participant.getId())
+                .curriculumItem(curriculumItem2)
+                .build();
+        ParticipantCurriculumItem participantCurriculumItem3 = ParticipantCurriculumItem.builder()
+                .participantId(participant.getId())
+                .curriculumItem(curriculumItem3)
+                .build();
+        participantCurriculumItemRepository.saveAll(
+                List.of(participantCurriculumItem1, participantCurriculumItem2, participantCurriculumItem3));
+
+        curriculumItemCommandService.manageCurriculum(request, study.getId(), memberId);
+
+        //when
+        List<ParticipantCurriculumItem> items = participantCurriculumItemRepository.findAll();
+        List<PersonalCurriculumItemResponse> responses = curriculumItemQueryService.getMyCurriculum(study.getId(),
+                memberId);
+
+        //then
+        assertThat(responses).hasSize(items.size());
+        System.out.println(responses);
+        assertThat(responses.get(0).id()).isEqualTo(items.get(0).getId());
+        assertThat(responses.get(1).id()).isEqualTo(items.get(1).getId());
+        assertThat(responses.get(2).id()).isEqualTo(items.get(2).getId());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #219

## 📝 작업 내용

bug
- 커리큘럼이 정상적으로 생성되지 않는 문제를 해결했습니다.
  - 커리큘럼 생성시 전체 커리큘럼 id를 기준으로 하지 않고 스터디 내의 커리큘럼을 기준으로 수정함
  - 따라서 현재 내 스터디의 커리큘럼이 아닌, 기존 해당 id를 지니고 있던 다른 스터디의 커리큘럼이 수정됨
  - 당연히 조회도 불가
  - 새로 생성된 id의 경우 null값으로 프론트에서 전달받는 것으로 수정  (프론트측의 로직 수정 필요, 전달함)
  

refactoring
- 도메인별 책임 분리 진행
- 파라미터로 List를 받아와 stream으로 처리하는 메서드들을 요소를 받아오도록 수정 (개인적으로 이 편이 코드도 간단해지고 이후 기능 수정할 일이 있을 때 수정이 편해지더라구요)
- 쿼리가 2번 발생하는 기존 update 방식을 쿼리가 한번만 발생하도록 수정  