### PR TITLE
fix: itemOrder가 중복되고 제대로 정렬되지 않는 문제 해결

### DIFF
--- a/src/main/java/doore/study/application/CurriculumItemCommandService.java
+++ b/src/main/java/doore/study/application/CurriculumItemCommandService.java
@@ -53,7 +53,7 @@ public class CurriculumItemCommandService {
 
         final List<CurriculumItemManageDetailRequest> deletedCurriculumItems = request.deletedCurriculumItems();
         deleteCurriculum(deletedCurriculumItems);
-        sortCurriculum();
+        sortCurriculum(studyId);
     }
 
     public void checkCurriculum(final Long curriculumId, final Long participantId, final Long memberId) {
@@ -135,9 +135,9 @@ public class CurriculumItemCommandService {
                 });
     }
 
-    private void sortCurriculum() {
-        final List<CurriculumItem> sortedCurriculum = curriculumItemRepository.findAllByOrderByItemOrderAsc();
-
+    private void sortCurriculum(final Long studyId) {
+        final List<CurriculumItem> sortedCurriculum = curriculumItemRepository.findAllByStudyIdOrderByItemOrderAsc(
+                studyId);
         IntStream.range(0, sortedCurriculum.size())
                 .forEach(i -> sortedCurriculum.get(i).updateItemOrder(i + 1));
         curriculumItemRepository.saveAll(sortedCurriculum);

--- a/src/main/java/doore/study/application/CurriculumItemQueryService.java
+++ b/src/main/java/doore/study/application/CurriculumItemQueryService.java
@@ -5,6 +5,7 @@ import doore.study.application.dto.response.PersonalCurriculumItemResponse;
 import doore.study.domain.ParticipantCurriculumItem;
 import doore.study.domain.repository.CurriculumItemRepository;
 import doore.study.domain.repository.ParticipantCurriculumItemRepository;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,7 +19,7 @@ public class CurriculumItemQueryService {
     private final ParticipantCurriculumItemRepository participantCurriculumItemRepository;
 
     public List<CurriculumItemResponse> getCurriculums(final Long studyId) {
-        return CurriculumItemResponse.from(curriculumItemRepository.findAllByStudyId(studyId));
+        return CurriculumItemResponse.from(curriculumItemRepository.findAllByStudyIdOrderByItemOrderAsc(studyId));
     }
 
     public List<PersonalCurriculumItemResponse> getMyCurriculum(final Long studyId, final Long memberId) {
@@ -26,6 +27,7 @@ public class CurriculumItemQueryService {
                 participantCurriculumItemRepository.findAllByStudyIdAndMemberId(studyId, memberId);
         return participantCurriculumItems.stream()
                 .map(PersonalCurriculumItemResponse::from)
+                .sorted(Comparator.comparingInt(PersonalCurriculumItemResponse::itemOrder))
                 .toList();
     }
 }

--- a/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
+++ b/src/main/java/doore/study/domain/repository/CurriculumItemRepository.java
@@ -16,4 +16,6 @@ public interface CurriculumItemRepository extends JpaRepository<CurriculumItem, 
     List<Long> findIdsByStudyId(Long studyId);
 
     Long countByStudyId(Long studyId);
+
+    List<CurriculumItem> findAllByStudyIdOrderByItemOrderAsc(Long studyId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #225 

## 📝 작업 내용

- 커리큘럼 조회 시 itemOrder가 중복되던 문제 해결
- 커리큘럼 조회 시 itemOrder의 순서가 정렬되지 않았던 부분 해결
