### PR TITLE
Feature/#228 팀 생성 시 이미지 파일이 없으면 팀 생성이 불가한 문제 해결

### DIFF
--- a/src/main/java/doore/team/application/TeamCommandService.java
+++ b/src/main/java/doore/team/application/TeamCommandService.java
@@ -59,11 +59,12 @@ public class TeamCommandService {
     private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
 
     private static final String INVITE_LINK_PREFIX = "teamId=%d";
+    private static final String DEFAULT_IMAGE_URL = "https://www.google.com";
 
     public void createTeam(final TeamCreateRequest request, final MultipartFile file, final Long memberId) {
         // TODO: 팀 생성자를 팀 관리자로 등록 (2024/5/9 완료)
         Member member = validateExistMember(memberId);
-        final String imageUrl = s3ImageFileService.upload(file);
+        final String imageUrl = (file != null && !file.isEmpty()) ? s3ImageFileService.upload(file) : DEFAULT_IMAGE_URL;
         try {
             final Team team = Team.builder()
                     .name(request.name())

--- a/src/main/java/doore/team/application/TeamCommandService.java
+++ b/src/main/java/doore/team/application/TeamCommandService.java
@@ -64,6 +64,7 @@ public class TeamCommandService {
     public void createTeam(final TeamCreateRequest request, final MultipartFile file, final Long memberId) {
         // TODO: 팀 생성자를 팀 관리자로 등록 (2024/5/9 완료)
         Member member = validateExistMember(memberId);
+        // TODO: 기본이미지 URL 재설정 필요
         final String imageUrl = (file != null && !file.isEmpty()) ? s3ImageFileService.upload(file) : DEFAULT_IMAGE_URL;
         try {
             final Team team = Team.builder()

--- a/src/main/java/doore/team/application/TeamCommandService.java
+++ b/src/main/java/doore/team/application/TeamCommandService.java
@@ -59,13 +59,13 @@ public class TeamCommandService {
     private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
 
     private static final String INVITE_LINK_PREFIX = "teamId=%d";
-    private static final String DEFAULT_IMAGE_URL = "https://www.google.com";
+    private static final String DEFAULT_IMAGE_URL = "https://doo-re-dev-bucket2.s3.ap-northeast-2.amazonaws.com/logo/logo.png";
 
     public void createTeam(final TeamCreateRequest request, final MultipartFile file, final Long memberId) {
         // TODO: 팀 생성자를 팀 관리자로 등록 (2024/5/9 완료)
         Member member = validateExistMember(memberId);
-        // TODO: 기본이미지 URL 재설정 필요
         final String imageUrl = (file != null && !file.isEmpty()) ? s3ImageFileService.upload(file) : DEFAULT_IMAGE_URL;
+
         try {
             final Team team = Team.builder()
                     .name(request.name())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #228

## 📝 작업 내용

- 팀 생성 시 이미지가 없으면 생성이 되지 않던 문제를 해결하였습니다.
- 아직 기본이미지가 없고, S3에 저장되어 있지 않아서 이 부분 정해지면 재수정 예정입니다. (지금 경로 해둔건 임시)
- 윗 comment 수정되면 pr merge하도록 하겠습니다!
