### PR TITLE
Feature/#242 팀원 삭제 후 재초대 시 팀원 조회에서 발생하는 서버 에러 해결

### DIFF
--- a/src/main/java/doore/member/application/MemberTeamCommandService.java
+++ b/src/main/java/doore/member/application/MemberTeamCommandService.java
@@ -2,11 +2,16 @@ package doore.member.application;
 
 import static doore.member.exception.MemberTeamExceptionType.CANNOT_DELETE_TEAM_LEADER;
 
+import doore.member.application.convenience.StudyRoleConvenience;
 import doore.member.application.convenience.TeamRoleConvenience;
 import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.member.domain.repository.MemberTeamRepository;
 import doore.member.exception.MemberTeamException;
+import doore.study.application.convenience.ParticipantConvenience;
+import doore.study.application.convenience.StudyConvenience;
+import doore.study.domain.Study;
 import doore.team.application.convenience.TeamValidateAccessPermission;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,12 +26,16 @@ public class MemberTeamCommandService {
     private final TeamValidateAccessPermission teamValidateAccessPermission;
 
     private final TeamRoleConvenience teamRoleConvenience;
+    private final StudyConvenience studyConvenience;
+    private final StudyRoleConvenience studyRoleConvenience;
+    private final ParticipantConvenience participantConvenience;
 
     public void deleteMemberTeam(final Long teamId, final Long deleteMemberId, final Long teamLeaderId) {
         teamValidateAccessPermission.validateExistTeam(teamId);
         checkIsEqualDeleteMemberIdAndTeamLeaderId(deleteMemberId, teamLeaderId);
         teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, teamLeaderId);
         teamRoleValidateAccessPermission.validateExistMemberTeam(teamId, deleteMemberId);
+        deleteStudiesAndParticipants(teamId, deleteMemberId);
         memberTeamRepository.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
         teamRoleConvenience.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
     }
@@ -35,5 +44,15 @@ public class MemberTeamCommandService {
         if (deleteMemberId.equals(teamLeaderId)) {
             throw new MemberTeamException(CANNOT_DELETE_TEAM_LEADER);
         }
+    }
+
+    private void deleteStudiesAndParticipants(final Long teamId, final Long deleteMemberId) {
+        List<Study> studies = studyConvenience.findAllByTeamIdAndMemberId(teamId, deleteMemberId);
+        studyRoleConvenience.isStudyLeader(studies, deleteMemberId);
+
+        studies.forEach(study -> {
+            participantConvenience.deleteByParticipantIdAndMemberId(study.getId(), deleteMemberId);
+            studyRoleConvenience.deleteByStudyIdAndMemberId(study.getId(), deleteMemberId);
+        });
     }
 }

--- a/src/main/java/doore/member/application/MemberTeamCommandService.java
+++ b/src/main/java/doore/member/application/MemberTeamCommandService.java
@@ -1,6 +1,6 @@
 package doore.member.application;
 
-import static doore.member.exception.MemberTeamExceptionType.CANNOT_DELETE_TEAM_LEADER;
+import static doore.member.exception.MemberTeamExceptionType.CANNOT_DELETE_TEAM_LEADER_SELF;
 
 import doore.member.application.convenience.StudyRoleConvenience;
 import doore.member.application.convenience.TeamRoleConvenience;
@@ -42,7 +42,7 @@ public class MemberTeamCommandService {
 
     private void checkIsEqualDeleteMemberIdAndTeamLeaderId(final Long deleteMemberId, final Long teamLeaderId) {
         if (deleteMemberId.equals(teamLeaderId)) {
-            throw new MemberTeamException(CANNOT_DELETE_TEAM_LEADER);
+            throw new MemberTeamException(CANNOT_DELETE_TEAM_LEADER_SELF);
         }
     }
 

--- a/src/main/java/doore/member/application/MemberTeamCommandService.java
+++ b/src/main/java/doore/member/application/MemberTeamCommandService.java
@@ -1,5 +1,6 @@
 package doore.member.application;
 
+import doore.member.application.convenience.TeamRoleConvenience;
 import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.member.domain.repository.MemberTeamRepository;
 import doore.team.application.convenience.TeamValidateAccessPermission;
@@ -16,10 +17,13 @@ public class MemberTeamCommandService {
     private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
     private final TeamValidateAccessPermission teamValidateAccessPermission;
 
+    private final TeamRoleConvenience teamRoleConvenience;
+
     public void deleteMemberTeam(final Long teamId, final Long deleteMemberId, final Long teamLeaderId) {
         teamValidateAccessPermission.validateExistTeam(teamId);
         teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, teamLeaderId);
         teamRoleValidateAccessPermission.validateExistMemberTeam(teamId, deleteMemberId);
         memberTeamRepository.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
+        teamRoleConvenience.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
     }
 }

--- a/src/main/java/doore/member/application/MemberTeamCommandService.java
+++ b/src/main/java/doore/member/application/MemberTeamCommandService.java
@@ -1,8 +1,11 @@
 package doore.member.application;
 
+import static doore.member.exception.MemberTeamExceptionType.CANNOT_DELETE_TEAM_LEADER;
+
 import doore.member.application.convenience.TeamRoleConvenience;
 import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.member.domain.repository.MemberTeamRepository;
+import doore.member.exception.MemberTeamException;
 import doore.team.application.convenience.TeamValidateAccessPermission;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,9 +24,16 @@ public class MemberTeamCommandService {
 
     public void deleteMemberTeam(final Long teamId, final Long deleteMemberId, final Long teamLeaderId) {
         teamValidateAccessPermission.validateExistTeam(teamId);
+        checkIsEqualDeleteMemberIdAndTeamLeaderId(deleteMemberId, teamLeaderId);
         teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, teamLeaderId);
         teamRoleValidateAccessPermission.validateExistMemberTeam(teamId, deleteMemberId);
         memberTeamRepository.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
         teamRoleConvenience.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
+    }
+
+    private void checkIsEqualDeleteMemberIdAndTeamLeaderId(final Long deleteMemberId, final Long teamLeaderId) {
+        if (deleteMemberId.equals(teamLeaderId)) {
+            throw new MemberTeamException(CANNOT_DELETE_TEAM_LEADER);
+        }
     }
 }

--- a/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
@@ -1,12 +1,16 @@
 package doore.member.application.convenience;
 
-import static doore.member.domain.StudyRoleType.*;
+import static doore.member.domain.StudyRoleType.ROLE_스터디원;
+import static doore.member.domain.StudyRoleType.ROLE_스터디장;
+import static doore.member.exception.MemberExceptionType.CANNOT_DELETE_STUDY_LEADER;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
 
 import doore.member.domain.StudyRole;
 import doore.member.domain.StudyRoleType;
 import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.exception.MemberException;
+import doore.study.domain.Study;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,5 +47,18 @@ public class StudyRoleConvenience {
 
     public Long findStudyLeaderId(final Long studyId) {
         return studyRoleRepository.findLeaderIdByStudyId(studyId);
+    }
+
+    public void isStudyLeader(final List<Study> studies, final Long memberId) {
+        boolean isStudyLeader = studies.stream().anyMatch(
+                study -> studyRoleRepository.existsByStudyIdAndMemberIdAndStudyRoleType(study.getId(), memberId,
+                        ROLE_스터디장));
+        if (isStudyLeader) {
+            throw new MemberException(CANNOT_DELETE_STUDY_LEADER);
+        }
+    }
+
+    public void deleteByStudyIdAndMemberId(final Long studyId, final Long memberId) {
+        studyRoleRepository.deleteByStudyIdAndMemberId(studyId, memberId);
     }
 }

--- a/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
@@ -43,4 +43,10 @@ public class StudyRoleValidateAccessPermission {
         return studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
                 .orElseThrow(() -> new MemberException(UNAUTHORIZED));
     }
+
+    public boolean isStudyLeader(final Long studyId, final Long memberId) {
+        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
+        return ROLE_스터디장.equals(studyRole.getStudyRoleType());
+    }
 }

--- a/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
@@ -45,8 +45,8 @@ public class StudyRoleValidateAccessPermission {
     }
 
     public boolean isStudyLeader(final Long studyId, final Long memberId) {
-        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        return ROLE_스터디장.equals(studyRole.getStudyRoleType());
+        return studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
+                .map(studyRole -> ROLE_스터디장.equals(studyRole.getStudyRoleType()))
+                .orElse(false);
     }
 }

--- a/src/main/java/doore/member/application/convenience/TeamRoleConvenience.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleConvenience.java
@@ -30,4 +30,8 @@ public class TeamRoleConvenience {
                 .memberId(memberId)
                 .build());
     }
+
+    public void deleteByTeamIdAndMemberId(final Long teamId, final Long memberId) {
+        teamRoleRepository.deleteByTeamIdAndMemberId(teamId, memberId);
+    }
 }

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -1,6 +1,7 @@
 package doore.member.application.convenience;
 
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
+import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_TEAM;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 
@@ -42,5 +43,11 @@ public class TeamRoleValidateAccessPermission {
     public TeamRole getValidateExistMemberTeam(final Long teamId, final Long memberId) {
         return teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
                 .orElseThrow(() -> new MemberException(UNAUTHORIZED));
+    }
+
+    public boolean isTeamLeader(final Long teamId, final Long memberId) {
+        final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
+        return ROLE_팀장.equals(teamRole.getTeamRoleType());
     }
 }

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -1,7 +1,6 @@
 package doore.member.application.convenience;
 
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_TEAM;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 
@@ -46,8 +45,8 @@ public class TeamRoleValidateAccessPermission {
     }
 
     public boolean isTeamLeader(final Long teamId, final Long memberId) {
-        final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
-        return ROLE_팀장.equals(teamRole.getTeamRoleType());
+        return teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
+                .map(teamRole -> ROLE_팀장.equals(teamRole.getTeamRoleType()))
+                .orElse(false);
     }
 }

--- a/src/main/java/doore/member/domain/repository/ParticipantRepository.java
+++ b/src/main/java/doore/member/domain/repository/ParticipantRepository.java
@@ -11,4 +11,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     List<Participant> findAllByStudyId(Long studyId);
 
     List<Participant> findByMemberId(Long memberId);
+
+    void deleteByStudyIdAndMemberId(Long studyId, Long memberId);
 }

--- a/src/main/java/doore/member/domain/repository/StudyRoleRepository.java
+++ b/src/main/java/doore/member/domain/repository/StudyRoleRepository.java
@@ -11,4 +11,6 @@ public interface StudyRoleRepository extends JpaRepository<StudyRole, Long> {
     Optional<StudyRole> findStudyRoleByStudyIdAndStudyRoleType(Long studyId, StudyRoleType studyRoleType);
     @Query("SELECT sr.memberId FROM StudyRole sr WHERE sr.studyId = :studyId AND sr.studyRoleType = 'ROLE_스터디장'")
     Long findLeaderIdByStudyId(Long studyId);
+    boolean existsByStudyIdAndMemberIdAndStudyRoleType(Long studyId, Long memberId, StudyRoleType studyRoleType);
+    void deleteByStudyIdAndMemberId(final Long studyId, final Long memberId);
 }

--- a/src/main/java/doore/member/domain/repository/TeamRoleRepository.java
+++ b/src/main/java/doore/member/domain/repository/TeamRoleRepository.java
@@ -14,4 +14,5 @@ public interface TeamRoleRepository extends JpaRepository<TeamRole, Long> {
     @Query("SELECT tr.memberId FROM TeamRole tr WHERE tr.teamId = :teamId AND tr.teamRoleType = 'ROLE_팀장'")
     Long findLeaderIdByTeamId(Long teamId);
     List<TeamRole> findAllByTeamId(final Long teamId);
+    void deleteByTeamIdAndMemberId(final Long teamId, final Long memberId);
 }

--- a/src/main/java/doore/member/exception/MemberExceptionType.java
+++ b/src/main/java/doore/member/exception/MemberExceptionType.java
@@ -12,6 +12,7 @@ public enum MemberExceptionType implements BaseExceptionType {
     NOT_FOUND_MEMBER_IN_STUDY(HttpStatus.NOT_FOUND, "스터디 내 해당 회원을 찾을 수 없습니다."),
     ALREADY_JOIN_TEAM_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 팀원입니다."),
     ALREADY_JOIN_STUDY_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 스터디원입니다."),
+    CANNOT_DELETE_STUDY_LEADER(HttpStatus.BAD_REQUEST, "스터디장을 맡고 있다면 팀원 삭제가 불가능합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/member/exception/MemberTeamException.java
+++ b/src/main/java/doore/member/exception/MemberTeamException.java
@@ -1,0 +1,18 @@
+package doore.member.exception;
+
+import doore.base.BaseException;
+import doore.base.BaseExceptionType;
+
+public class MemberTeamException extends BaseException {
+    private final MemberTeamExceptionType exceptionType;
+
+    public MemberTeamException(final MemberTeamExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/doore/member/exception/MemberTeamExceptionType.java
+++ b/src/main/java/doore/member/exception/MemberTeamExceptionType.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum MemberTeamExceptionType implements BaseExceptionType {
 
-    CANNOT_DELETE_TEAM_LEADER(HttpStatus.BAD_REQUEST, "팀장 본인은 팀을 탈퇴할 수 없습니다."),
+    CANNOT_DELETE_TEAM_LEADER_SELF(HttpStatus.BAD_REQUEST, "팀장 본인은 팀을 탈퇴할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/member/exception/MemberTeamExceptionType.java
+++ b/src/main/java/doore/member/exception/MemberTeamExceptionType.java
@@ -1,0 +1,28 @@
+package doore.member.exception;
+
+import doore.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum MemberTeamExceptionType implements BaseExceptionType {
+
+    CANNOT_DELETE_TEAM_LEADER(HttpStatus.BAD_REQUEST, "팀장 본인은 팀을 탈퇴할 수 없습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    MemberTeamExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/doore/member/exception/MemberTeamExceptionType.java
+++ b/src/main/java/doore/member/exception/MemberTeamExceptionType.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum MemberTeamExceptionType implements BaseExceptionType {
 
-    CANNOT_DELETE_TEAM_LEADER(HttpStatus.BAD_REQUEST, "팀장 본인은 팀을 탈퇴할 수 없습니다.")
+    CANNOT_DELETE_TEAM_LEADER(HttpStatus.BAD_REQUEST, "팀장 본인은 팀을 탈퇴할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/member/exception/ParticipantException.java
+++ b/src/main/java/doore/member/exception/ParticipantException.java
@@ -1,0 +1,19 @@
+package doore.member.exception;
+
+import doore.base.BaseException;
+import doore.base.BaseExceptionType;
+
+public class ParticipantException extends BaseException {
+
+    private final ParticipantExceptionType exceptionType;
+
+    public ParticipantException(final ParticipantExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/doore/member/exception/ParticipantExceptionType.java
+++ b/src/main/java/doore/member/exception/ParticipantExceptionType.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ParticipantExceptionType implements BaseExceptionType {
 
-    CANNOT_DELETE_STUDY_LEADER(HttpStatus.BAD_REQUEST, "스터디장 본인은 팀을 탈퇴할 수 없습니다.")
+    CANNOT_DELETE_STUDY_LEADER(HttpStatus.BAD_REQUEST, "스터디장 본인은 팀을 탈퇴할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/member/exception/ParticipantExceptionType.java
+++ b/src/main/java/doore/member/exception/ParticipantExceptionType.java
@@ -1,0 +1,28 @@
+package doore.member.exception;
+
+import doore.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum ParticipantExceptionType implements BaseExceptionType {
+
+    CANNOT_DELETE_STUDY_LEADER(HttpStatus.BAD_REQUEST, "스터디장 본인은 팀을 탈퇴할 수 없습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    ParticipantExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/doore/member/exception/ParticipantExceptionType.java
+++ b/src/main/java/doore/member/exception/ParticipantExceptionType.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ParticipantExceptionType implements BaseExceptionType {
 
-    CANNOT_DELETE_STUDY_LEADER(HttpStatus.BAD_REQUEST, "스터디장 본인은 팀을 탈퇴할 수 없습니다."),
+    CANNOT_DELETE_STUDY_LEADER_SELF(HttpStatus.BAD_REQUEST, "스터디장 본인은 팀을 탈퇴할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -1,10 +1,13 @@
 package doore.study.application;
 
+import static doore.member.exception.ParticipantExceptionType.CANNOT_DELETE_STUDY_LEADER;
+
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleConvenience;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.domain.Member;
 import doore.member.domain.repository.ParticipantRepository;
+import doore.member.exception.ParticipantException;
 import doore.study.application.convenience.ParticipantConvenience;
 import doore.study.application.convenience.StudyValidateAccessPermission;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +38,7 @@ public class ParticipantCommandService {
     public void deleteParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
         studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, studyLeaderId);
         studyValidateAccessPermission.validateExistStudy(studyId);
+        checkIsEqualDeleteMemberIdAndStudyLeaderId(memberId, studyLeaderId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantRepository.deleteByStudyIdAndMember(studyId, member);
     }
@@ -44,5 +48,11 @@ public class ParticipantCommandService {
         studyValidateAccessPermission.validateExistStudy(studyId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantRepository.deleteByStudyIdAndMember(studyId, member);
+    }
+
+    private void checkIsEqualDeleteMemberIdAndStudyLeaderId(final Long deleteMemberId, final Long studyLeaderId) {
+        if (deleteMemberId.equals(studyLeaderId)) {
+            throw new ParticipantException(CANNOT_DELETE_STUDY_LEADER);
+        }
     }
 }

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -1,15 +1,20 @@
 package doore.study.application;
 
+import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.member.exception.ParticipantExceptionType.CANNOT_DELETE_STUDY_LEADER;
 
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleConvenience;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
+import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.member.domain.Member;
 import doore.member.domain.repository.ParticipantRepository;
+import doore.member.exception.MemberException;
 import doore.member.exception.ParticipantException;
 import doore.study.application.convenience.ParticipantConvenience;
+import doore.study.application.convenience.StudyConvenience;
 import doore.study.application.convenience.StudyValidateAccessPermission;
+import doore.study.domain.Study;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,8 +27,10 @@ public class ParticipantCommandService {
 
     private final StudyRoleConvenience studyRoleConvenience;
     private final ParticipantConvenience participantConvenience;
+    private final StudyConvenience studyConvenience;
 
     private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
+    private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
     private final MemberValidateAccessPermission memberValidateAccessPermission;
     private final StudyValidateAccessPermission studyValidateAccessPermission;
 
@@ -36,11 +43,12 @@ public class ParticipantCommandService {
     }
 
     public void deleteParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
-        studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, studyLeaderId);
         studyValidateAccessPermission.validateExistStudy(studyId);
+        checkStudyLeaderOrTeamLeader(studyId, studyLeaderId);
         checkIsEqualDeleteMemberIdAndStudyLeaderId(memberId, studyLeaderId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantRepository.deleteByStudyIdAndMember(studyId, member);
+        studyRoleConvenience.deleteByStudyIdAndMemberId(studyId, memberId);
     }
 
     public void withdrawParticipant(final Long studyId, final Long memberId, final Long participantId) {
@@ -48,11 +56,21 @@ public class ParticipantCommandService {
         studyValidateAccessPermission.validateExistStudy(studyId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantRepository.deleteByStudyIdAndMember(studyId, member);
+        studyRoleConvenience.deleteByStudyIdAndMemberId(studyId, memberId);
     }
 
     private void checkIsEqualDeleteMemberIdAndStudyLeaderId(final Long deleteMemberId, final Long studyLeaderId) {
         if (deleteMemberId.equals(studyLeaderId)) {
             throw new ParticipantException(CANNOT_DELETE_STUDY_LEADER);
+        }
+    }
+
+    private void checkStudyLeaderOrTeamLeader(final Long studyId, final Long memberId) {
+        final Study study = studyConvenience.findById(studyId);
+        final Long teamId = study.getTeamId();
+        if (!(studyRoleValidateAccessPermission.isStudyLeader(studyId, memberId)
+                || teamRoleValidateAccessPermission.isTeamLeader(teamId, memberId))) {
+            throw new MemberException(UNAUTHORIZED);
         }
     }
 }

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -1,7 +1,7 @@
 package doore.study.application;
 
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
-import static doore.member.exception.ParticipantExceptionType.CANNOT_DELETE_STUDY_LEADER;
+import static doore.member.exception.ParticipantExceptionType.CANNOT_DELETE_STUDY_LEADER_SELF;
 
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleConvenience;
@@ -44,8 +44,8 @@ public class ParticipantCommandService {
 
     public void deleteParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
         studyValidateAccessPermission.validateExistStudy(studyId);
-        checkStudyLeaderOrTeamLeader(studyId, memberId, studyLeaderId);
         checkIsEqualDeleteMemberIdAndStudyLeaderId(memberId, studyLeaderId);
+        checkStudyLeaderOrTeamLeader(studyId, memberId, studyLeaderId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantRepository.deleteByStudyIdAndMember(studyId, member);
         studyRoleConvenience.deleteByStudyIdAndMemberId(studyId, memberId);
@@ -61,7 +61,7 @@ public class ParticipantCommandService {
 
     private void checkIsEqualDeleteMemberIdAndStudyLeaderId(final Long deleteMemberId, final Long studyLeaderId) {
         if (deleteMemberId.equals(studyLeaderId)) {
-            throw new ParticipantException(CANNOT_DELETE_STUDY_LEADER);
+            throw new ParticipantException(CANNOT_DELETE_STUDY_LEADER_SELF);
         }
     }
 

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -44,7 +44,7 @@ public class ParticipantCommandService {
 
     public void deleteParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
         studyValidateAccessPermission.validateExistStudy(studyId);
-        checkStudyLeaderOrTeamLeader(studyId, studyLeaderId);
+        checkStudyLeaderOrTeamLeader(studyId, memberId, studyLeaderId);
         checkIsEqualDeleteMemberIdAndStudyLeaderId(memberId, studyLeaderId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantRepository.deleteByStudyIdAndMember(studyId, member);
@@ -65,12 +65,21 @@ public class ParticipantCommandService {
         }
     }
 
-    private void checkStudyLeaderOrTeamLeader(final Long studyId, final Long memberId) {
+    private void checkStudyLeaderOrTeamLeader(final Long studyId, final Long deleteMemberId, final Long leaderId) {
         final Study study = studyConvenience.findById(studyId);
         final Long teamId = study.getTeamId();
-        if (!(studyRoleValidateAccessPermission.isStudyLeader(studyId, memberId)
-                || teamRoleValidateAccessPermission.isTeamLeader(teamId, memberId))) {
+        if (!(studyRoleValidateAccessPermission.isStudyLeader(studyId, leaderId)
+                || teamRoleValidateAccessPermission.isTeamLeader(teamId, leaderId))) {
             throw new MemberException(UNAUTHORIZED);
+        }
+        assignStudyLeaderToTeamLeader(studyId, deleteMemberId, teamId, leaderId);
+    }
+
+    private void assignStudyLeaderToTeamLeader(final Long studyId, final Long deleteMemberId, final Long teamId,
+                                               final Long leaderId) {
+        if (studyRoleValidateAccessPermission.isStudyLeader(studyId, deleteMemberId)
+                && teamRoleValidateAccessPermission.isTeamLeader(teamId, leaderId)) {
+            studyRoleConvenience.assignStudyLeaderRole(studyId, leaderId);
         }
     }
 }

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -44,8 +44,8 @@ public class ParticipantCommandService {
 
     public void deleteParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
         studyValidateAccessPermission.validateExistStudy(studyId);
-        checkIsEqualDeleteMemberIdAndStudyLeaderId(memberId, studyLeaderId);
         checkStudyLeaderOrTeamLeader(studyId, memberId, studyLeaderId);
+        checkIsEqualDeleteMemberIdAndStudyLeaderId(memberId, studyLeaderId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantRepository.deleteByStudyIdAndMember(studyId, member);
         studyRoleConvenience.deleteByStudyIdAndMemberId(studyId, memberId);

--- a/src/main/java/doore/study/application/convenience/ParticipantConvenience.java
+++ b/src/main/java/doore/study/application/convenience/ParticipantConvenience.java
@@ -25,4 +25,8 @@ public class ParticipantConvenience {
         final List<Participant> participants = participantRepository.findAllByStudyId(studyId);
         participantRepository.deleteAll(participants);
     }
+
+    public void deleteByParticipantIdAndMemberId(final Long participantId, final Long memberId) {
+        participantRepository.deleteByStudyIdAndMemberId(participantId, memberId);
+    }
 }

--- a/src/main/java/doore/study/application/convenience/StudyConvenience.java
+++ b/src/main/java/doore/study/application/convenience/StudyConvenience.java
@@ -2,6 +2,7 @@ package doore.study.application.convenience;
 
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +17,11 @@ public class StudyConvenience {
         return studyRepository.findByDocumentId(documentId);
     }
 
-    public Study findByCurriculumItemId(Long curriculumId) {
+    public Study findByCurriculumItemId(final Long curriculumId) {
         return studyRepository.findByCurriculumItemId(curriculumId);
+    }
+
+    public List<Study> findAllByTeamIdAndMemberId(final Long teamId, final Long memberId) {
+        return studyRepository.findAllByTeamIdAndMemberId(teamId, memberId);
     }
 }

--- a/src/main/java/doore/study/application/convenience/StudyConvenience.java
+++ b/src/main/java/doore/study/application/convenience/StudyConvenience.java
@@ -1,7 +1,10 @@
 package doore.study.application.convenience;
 
+import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
+
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
+import doore.study.exception.StudyException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,5 +26,9 @@ public class StudyConvenience {
 
     public List<Study> findAllByTeamIdAndMemberId(final Long teamId, final Long memberId) {
         return studyRepository.findAllByTeamIdAndMemberId(teamId, memberId);
+    }
+
+    public Study findById(final Long studyId) {
+        return studyRepository.findById(studyId).orElseThrow(() -> new StudyException(NOT_FOUND_STUDY));
     }
 }

--- a/src/main/java/doore/study/domain/repository/StudyRepository.java
+++ b/src/main/java/doore/study/domain/repository/StudyRepository.java
@@ -20,4 +20,8 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
     Page<Study> findAllByTeamId(Long teamId, Pageable pageable);
     @Query("select s from Study s join Document d on d.groupId = s.id where d.id = :documentId")
     Study findByDocumentId(Long documentId);
+
+    @Query("SELECT s FROM Study s JOIN Participant p ON p.studyId = s.id " +
+            "WHERE p.member.id = :memberId AND s.teamId = :teamId")
+    List<Study> findAllByTeamIdAndMemberId(Long teamId, Long memberId);
 }

--- a/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
@@ -1,11 +1,15 @@
 package doore.member.application;
 
+import static doore.member.MemberFixture.미나;
 import static doore.member.MemberFixture.보름;
 import static doore.member.MemberFixture.아마란스;
 import static doore.member.MemberFixture.짱구;
 import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
+import static doore.member.exception.MemberExceptionType.CANNOT_DELETE_STUDY_LEADER;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+import static doore.member.exception.MemberTeamExceptionType.CANNOT_DELETE_TEAM_LEADER_SELF;
+import static doore.study.StudyFixture.algorithmStudy;
 import static doore.team.TeamFixture.team;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -13,11 +17,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
 import doore.member.domain.MemberTeam;
+import doore.member.domain.Participant;
+import doore.member.domain.StudyRole;
+import doore.member.domain.StudyRoleType;
 import doore.member.domain.TeamRole;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.MemberTeamRepository;
+import doore.member.domain.repository.ParticipantRepository;
+import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.domain.repository.TeamRoleRepository;
 import doore.member.exception.MemberException;
+import doore.member.exception.MemberTeamException;
+import doore.study.domain.Study;
+import doore.study.domain.repository.StudyRepository;
 import doore.team.domain.Team;
 import doore.team.domain.TeamRepository;
 import java.util.List;
@@ -36,6 +48,12 @@ public class MemberTeamCommandServiceTest extends IntegrationTest {
     private MemberTeamRepository memberTeamRepository;
     @Autowired
     private TeamRoleRepository teamRoleRepository;
+    @Autowired
+    private StudyRepository studyRepository;
+    @Autowired
+    private ParticipantRepository participantRepository;
+    @Autowired
+    private StudyRoleRepository studyRoleRepository;
     @Autowired
     private MemberTeamCommandService memberTeamCommandService;
 
@@ -107,5 +125,42 @@ public class MemberTeamCommandServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> {
             memberTeamCommandService.deleteMemberTeam(team.getId(), otherTeamMember.getId(), teamLeader.getId());
         }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 팀장은 팀장 본인을 탈퇴 시킬 수 없다.")
+    public void deleteMemberTeam_팀장은_팀장_본인을_탈퇴_시킬_수_없다_실패() throws Exception {
+        assertThatThrownBy(() -> {
+            memberTeamCommandService.deleteMemberTeam(team.getId(), teamLeader.getId(), teamLeader.getId());
+        }).isInstanceOf(MemberTeamException.class).hasMessage(CANNOT_DELETE_TEAM_LEADER_SELF.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 팀장은 스터디장인 팀원을 탈퇴 시킬 수 없다.")
+    public void deleteMemberTeam_팀장은_스터디장인_팀원을_탈퇴_시킬_수_없다_실패() throws Exception {
+        final Study study = studyRepository.save(algorithmStudy());
+        final Member studyLeaderMember = memberRepository.save(미나());
+        memberTeamRepository.save(MemberTeam.builder()
+                .member(studyLeaderMember)
+                .teamId(team.getId())
+                .build());
+        teamRoleRepository.save(TeamRole.builder()
+                .memberId(studyLeaderMember.getId())
+                .teamRoleType(ROLE_팀원)
+                .teamId(team.getId())
+                .build());
+        participantRepository.save(Participant.builder()
+                .member(studyLeaderMember)
+                .studyId(study.getId())
+                .build());
+        studyRoleRepository.save(StudyRole.builder()
+                .studyId(study.getId())
+                .studyRoleType(StudyRoleType.ROLE_스터디장)
+                .memberId(studyLeaderMember.getId())
+                .build());
+
+        assertThatThrownBy(() -> {
+            memberTeamCommandService.deleteMemberTeam(team.getId(), studyLeaderMember.getId(), teamLeader.getId());
+        }).isInstanceOf(MemberException.class).hasMessage(CANNOT_DELETE_STUDY_LEADER.errorMessage());
     }
 }

--- a/src/test/java/doore/member/application/MemberTeamQueryServiceTest.java
+++ b/src/test/java/doore/member/application/MemberTeamQueryServiceTest.java
@@ -11,7 +11,7 @@ import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
 import static doore.team.TeamFixture.team;
 import static java.util.stream.Collectors.toMap;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import doore.helper.IntegrationTest;
 import doore.member.application.dto.response.TeamMemberResponse;
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class MemberTeamQueryServiceTest extends IntegrationTest {
+    @Autowired
+    private MemberTeamCommandService memberTeamCommandService;
     @Autowired
     private MemberTeamQueryService memberTeamQueryService;
     @Autowired
@@ -65,15 +67,16 @@ class MemberTeamQueryServiceTest extends IntegrationTest {
         비비아마 = memberRepository.save(비비아마());
         아마 = memberRepository.save(아마());
 
-        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마란스).isDeleted(false).build());
-        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마어마어마).isDeleted(false).build());
-        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(아마스).isDeleted(false).build());
-        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(보름).isDeleted(false).build());
-        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(짱구).isDeleted(false).build());
-        memberTeamRepository.save(MemberTeam.builder().teamId(1L).member(비비아마).isDeleted(false).build());
+        team = teamRepository.save(team());
+
+        memberTeamRepository.save(MemberTeam.builder().teamId(team.getId()).member(아마란스).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(team.getId()).member(아마어마어마).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(team.getId()).member(아마스).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(team.getId()).member(보름).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(team.getId()).member(짱구).isDeleted(false).build());
+        memberTeamRepository.save(MemberTeam.builder().teamId(team.getId()).member(비비아마).isDeleted(false).build());
         memberTeamRepository.save(MemberTeam.builder().teamId(2L).member(아마).isDeleted(false).build());
 
-        team = teamRepository.save(team());
         teamLeaderRole = teamRoleRepository.save(
                 TeamRole.builder().teamId(team.getId()).memberId(보름.getId()).teamRoleType(ROLE_팀장).build());
         teamMemberRole = teamRoleRepository.save(
@@ -158,5 +161,35 @@ class MemberTeamQueryServiceTest extends IntegrationTest {
         Assertions.assertThat(actual)
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("[성공] 팀원 삭제 후 재초대 시 정상적으로 팀원 목록 조회가 된다.")
+    void findMemberTeams_팀원_삭제_후_재초대_시_정상적으로_팀원_목록_조회가_된다_성공() {
+        //given
+        memberTeamCommandService.deleteMemberTeam(team.getId(), 아마스.getId(), 보름.getId());
+        memberTeamRepository.save(MemberTeam.builder().teamId(team.getId()).member(아마스).isDeleted(false).build());
+        teamRoleRepository.save(
+                TeamRole.builder().teamId(team.getId()).memberId(아마스.getId()).teamRoleType(ROLE_팀원).build());
+
+        final List<MemberTeam> memberTeams = memberTeamRepository.findAllByTeamId(team.getId());
+        final List<Member> members = memberTeams.stream()
+                .map(MemberTeam::getMember)
+                .toList();
+        final Map<Member, TeamRoleType> roleOfMembers = members.stream()
+                .collect(toMap(
+                        member -> member,
+                        member -> teamRoleRepository.findTeamRoleByMemberId(member.getId())
+                                .orElseThrow()
+                                .getTeamRoleType()
+                ));
+        final List<TeamMemberResponse> expected = TeamMemberResponse.of(members, roleOfMembers);
+
+        //when
+        final List<TeamMemberResponse> actual = memberTeamQueryService.findMemberTeams(team.getId(), null,
+                teamMemberRole.getId());
+
+        //then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
     }
 }

--- a/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
+++ b/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
@@ -1,8 +1,11 @@
 package doore.study.application;
 
 import static doore.member.MemberFixture.createMember;
+import static doore.member.MemberFixture.미나;
 import static doore.member.MemberFixture.아마란스;
+import static doore.member.domain.TeamRoleType.ROLE_팀장;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+import static doore.member.exception.ParticipantExceptionType.CANNOT_DELETE_STUDY_LEADER_SELF;
 import static doore.study.StudyFixture.algorithmStudy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -11,12 +14,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
+import doore.member.domain.Participant;
 import doore.member.domain.StudyRole;
 import doore.member.domain.StudyRoleType;
+import doore.member.domain.TeamRole;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.ParticipantRepository;
 import doore.member.domain.repository.StudyRoleRepository;
+import doore.member.domain.repository.TeamRoleRepository;
 import doore.member.exception.MemberException;
+import doore.member.exception.ParticipantException;
 import doore.study.application.dto.response.ParticipantResponse;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
@@ -40,19 +47,29 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
     private StudyRoleRepository studyRoleRepository;
     @Autowired
     private ParticipantRepository participantRepository;
+    @Autowired
+    private TeamRoleRepository teamRoleRepository;
 
+    private Member teamLeader;
     private Member member;
     private Study study;
     private StudyRole studyRole;
+    private TeamRole teamRole;
 
     @BeforeEach
     void setUp() {
+        teamLeader = memberRepository.save(미나());
         member = memberRepository.save(아마란스());
         study = studyRepository.save(algorithmStudy());
         studyRole = studyRoleRepository.save(StudyRole.builder()
                 .studyRoleType(StudyRoleType.ROLE_스터디장)
                 .studyId(study.getId())
                 .memberId(member.getId())
+                .build());
+        teamRole = teamRoleRepository.save(TeamRole.builder()
+                .teamId(study.getTeamId())
+                .teamRoleType(ROLE_팀장)
+                .memberId(teamLeader.getId())
                 .build());
     }
 
@@ -85,7 +102,8 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
             final Long notExistingMemberId = 50L;
 
             assertThatThrownBy(
-                    () -> participantCommandService.createParticipant(study.getId(), notExistingMemberId, member.getId()))
+                    () -> participantCommandService.createParticipant(study.getId(), notExistingMemberId,
+                            member.getId()))
                     .isInstanceOf(MemberException.class)
                     .hasMessage(UNAUTHORIZED.errorMessage());
         }
@@ -103,6 +121,36 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
 
             //then
             assertThat(participantRepository.findByMemberId(participant.getId()).get(0).getIsDeleted()).isEqualTo(true);
+        }
+
+        @Test
+        @DisplayName("[실패] 스터디장은 스터디장 본인을 탈퇴 시킬 수 없다.")
+        public void deleteParticipant_스터디장은_스터디장_본인을_탈퇴_시킬_수_없다_실패() throws Exception {
+            assertThatThrownBy(() -> {
+                participantCommandService.deleteParticipant(study.getId(), member.getId(), member.getId());
+            }).isInstanceOf(ParticipantException.class).hasMessage(CANNOT_DELETE_STUDY_LEADER_SELF.errorMessage());
+        }
+
+        @Test
+        @DisplayName("[성공] 팀장은 스터디장을 탈퇴 시킬 수 있다.")
+        public void deleteParticipant_팀장은_스터디장을_탈퇴_시킬_수_있다_성공() {
+            participantRepository.save(Participant.builder().studyId(study.getId()).member(member).build());
+
+            participantCommandService.deleteParticipant(study.getId(), member.getId(), teamLeader.getId());
+
+            assertThat(participantRepository.findByMemberId(member.getId()).get(0).getIsDeleted()).isEqualTo(true);
+        }
+
+        @Test
+        @DisplayName("[성공] 팀장이 스터디장을 탈퇴 시킬 경우 스터디장 권한은 팀장에게 위임된다.")
+        public void deleteParticipant_팀장이_스터디장을_탈퇴_시킬_경우_스터디장_권한은_팀장에게_위임된다_성공() {
+            participantRepository.save(Participant.builder().studyId(study.getId()).member(member).build());
+            participantCommandService.deleteParticipant(study.getId(), member.getId(), teamLeader.getId());
+
+            StudyRole afterStudyLeader = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(study.getId(),
+                    teamLeader.getId()).orElseThrow();
+
+            assertThat(afterStudyLeader.getMemberId()).isEqualTo(teamLeader.getId());
         }
 
         @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #242 

## 📝 작업 내용

- 이번 버그는 팀원 삭제 시 팀원 직위를 삭제하지 않아 재가입 시 2개의 컬럼이 존재하게 되어 나타난 오류였습니다!
- 따라서 이 문제를 팀원 삭제 시 팀원 직위를 삭제하는 방법으로 해결하였고, 그에 따른 테스트를 작성하였습니다
- 또한 팀원 삭제 시 스터디 관련한 것들도 삭제되도록 변경하였습니다!

## 💬 리뷰 요구사항

- 팀원 삭제 로직에 변경이 있습니다.
    - 팀장은 팀장 본인 삭제 불가
    - 스터디장은 스터디장 본인 삭제 불가
    - 팀장은 스터디장으로 임명된 팀원 삭제 불가 (스터디장 위임 권한이 스터디장에게 있기 때문에 스터디장 삭제 시 해당 스터디의 스터디장이 없어지게 됨)
        - 단, 악용을 막기 위해(1인 스터디를 만들면 팀장이 팀원을 삭제할 수 없게 됨) 스터디원 삭제 권한을 팀장과 스터디장으로 변경
        - 또한 팀장이 스터디장을 삭제할 때 스터디장이 없어지는 것을 방지하기 위해 팀장이 해당 스터디의 스터디장 권한을 가지도록 변경