### PR TITLE
Feature/#240 스터디원 중복 추가 불가 기능 개발

### DIFF
--- a/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
@@ -1,8 +1,5 @@
 package doore.member.application.convenience;
 
-import static doore.member.domain.StudyRoleType.*;
-import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
-
 import doore.member.domain.StudyRole;
 import doore.member.domain.StudyRoleType;
 import doore.member.domain.repository.StudyRoleRepository;
@@ -11,11 +8,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static doore.member.domain.StudyRoleType.ROLE_스터디원;
+import static doore.member.domain.StudyRoleType.ROLE_스터디장;
+import static doore.member.exception.MemberExceptionType.ALREADY_JOIN_STUDY_MEMBER;
+import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class StudyRoleConvenience {
     private final StudyRoleRepository studyRoleRepository;
+
+    public void duplicateCheckStudyMember(final Long studyId, final Long memberId) {
+        if (studyRoleRepository.existsByStudyIdAndMemberId(studyId, memberId)) {
+            throw new MemberException(ALREADY_JOIN_STUDY_MEMBER);
+        }
+    }
 
     public void assignStudyLeaderRole(final Long studyId, final Long memberId) {
         studyRoleRepository.save(StudyRole.builder()

--- a/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
@@ -19,7 +19,7 @@ import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_I
 public class StudyRoleConvenience {
     private final StudyRoleRepository studyRoleRepository;
 
-    public void duplicateCheckStudyMember(final Long studyId, final Long memberId) {
+    public void duplicateCheckStudyParticipant(final Long studyId, final Long memberId) {
         if (studyRoleRepository.existsByStudyIdAndMemberId(studyId, memberId)) {
             throw new MemberException(ALREADY_JOIN_STUDY_MEMBER);
         }

--- a/src/main/java/doore/member/domain/repository/StudyRoleRepository.java
+++ b/src/main/java/doore/member/domain/repository/StudyRoleRepository.java
@@ -2,13 +2,18 @@ package doore.member.domain.repository;
 
 import doore.member.domain.StudyRole;
 import doore.member.domain.StudyRoleType;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface StudyRoleRepository extends JpaRepository<StudyRole, Long> {
+    Boolean existsByStudyIdAndMemberId(Long studyId, Long memberId);
+
     Optional<StudyRole> findStudyRoleByStudyIdAndMemberId(Long studyId, Long memberId);
+
     Optional<StudyRole> findStudyRoleByStudyIdAndStudyRoleType(Long studyId, StudyRoleType studyRoleType);
+
     @Query("SELECT sr.memberId FROM StudyRole sr WHERE sr.studyId = :studyId AND sr.studyRoleType = 'ROLE_스터디장'")
     Long findLeaderIdByStudyId(Long studyId);
 }

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -27,6 +27,7 @@ public class ParticipantCommandService {
     public void createParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
         studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, studyLeaderId);
         studyValidateAccessPermission.validateExistStudy(studyId);
+        studyRoleConvenience.duplicateCheckStudyMember(studyId, memberId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantConvenience.assignParticipant(studyId, member);
         studyRoleConvenience.assignParticipantRole(studyId, memberId, studyLeaderId);

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -27,7 +27,7 @@ public class ParticipantCommandService {
     public void createParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
         studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, studyLeaderId);
         studyValidateAccessPermission.validateExistStudy(studyId);
-        studyRoleConvenience.duplicateCheckStudyMember(studyId, memberId);
+        studyRoleConvenience.duplicateCheckStudyParticipant(studyId, memberId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantConvenience.assignParticipant(studyId, member);
         studyRoleConvenience.assignParticipantRole(studyId, memberId, studyLeaderId);

--- a/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
+++ b/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
@@ -1,14 +1,5 @@
 package doore.study.application;
 
-import static doore.member.MemberFixture.createMember;
-import static doore.member.MemberFixture.아마란스;
-import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
-import static doore.study.StudyFixture.algorithmStudy;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
@@ -20,12 +11,23 @@ import doore.member.exception.MemberException;
 import doore.study.application.dto.response.ParticipantResponse;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static doore.member.MemberFixture.createMember;
+import static doore.member.MemberFixture.아마란스;
+import static doore.member.exception.MemberExceptionType.ALREADY_JOIN_STUDY_MEMBER;
+import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+import static doore.study.StudyFixture.algorithmStudy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParticipantCommandServiceTest extends IntegrationTest {
     @Autowired
@@ -65,18 +67,31 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
         void createParticipant_정상적으로_참여자를_추가할_수_있다_성공() {
             //Given
             final Long studyId = study.getId();
-            final Long memberId = member.getId();
+            final Member participant = createMember();
 
             //when
-            participantCommandService.createParticipant(studyId, memberId, member.getId());
+            participantCommandService.createParticipant(studyId, participant.getId(), member.getId());
 
             //then
             final List<ParticipantResponse> participantResponses = participantQueryService.getParticipants(studyId,
-                    memberId);
+                    participant.getId());
             assertAll(
                     () -> assertThat(participantResponses).hasSize(1),
-                    () -> assertEquals(memberId, participantResponses.get(0).memberId())
+                    () -> assertEquals(participant.getId(), participantResponses.get(0).memberId())
             );
+        }
+
+        @Test
+        @DisplayName("[실패] 이미 가입된 스티디원이라면 중복해서 초대를 할 수 없다.")
+        void createParticipant_이미_가입된_스터디원이라면_중복해서_초대를_할_수_없다_실패() {
+            final Long studyId = study.getId();
+            final Member participant = createMember();
+
+            participantCommandService.createParticipant(studyId, participant.getId(), member.getId());
+            assertThatThrownBy(
+                    () -> participantCommandService.createParticipant(studyId, participant.getId(), member.getId()))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(ALREADY_JOIN_STUDY_MEMBER.errorMessage());
         }
 
         @Test

--- a/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
+++ b/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
@@ -85,11 +85,11 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
         @DisplayName("[실패] 이미 가입된 스티디원이라면 중복해서 초대를 할 수 없다.")
         void createParticipant_이미_가입된_스터디원이라면_중복해서_초대를_할_수_없다_실패() {
             final Long studyId = study.getId();
-            final Member participant = createMember();
+            final Member alreadyJoinedParticipant = createMember();
 
-            participantCommandService.createParticipant(studyId, participant.getId(), member.getId());
+            participantCommandService.createParticipant(studyId, alreadyJoinedParticipant.getId(), member.getId());
             assertThatThrownBy(
-                    () -> participantCommandService.createParticipant(studyId, participant.getId(), member.getId()))
+                    () -> participantCommandService.createParticipant(studyId, alreadyJoinedParticipant.getId(), member.getId()))
                     .isInstanceOf(MemberException.class)
                     .hasMessage(ALREADY_JOIN_STUDY_MEMBER.errorMessage());
         }

--- a/src/test/java/doore/study/application/ParticipantQueryTest.java
+++ b/src/test/java/doore/study/application/ParticipantQueryTest.java
@@ -1,14 +1,5 @@
 package doore.study.application;
 
-import static doore.member.MemberFixture.보름;
-import static doore.member.MemberFixture.아마란스;
-import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
-import static doore.study.StudyFixture.algorithmStudy;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
@@ -19,12 +10,22 @@ import doore.member.exception.MemberException;
 import doore.study.application.dto.response.ParticipantResponse;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static doore.member.MemberFixture.보름;
+import static doore.member.MemberFixture.아마란스;
+import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+import static doore.study.StudyFixture.algorithmStudy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParticipantQueryTest extends IntegrationTest {
     @Autowired
@@ -38,18 +39,20 @@ public class ParticipantQueryTest extends IntegrationTest {
     @Autowired
     private StudyRoleRepository studyRoleRepository;
 
+    private Member leader;
     private Member member;
     private Study study;
     private StudyRole studyRole;
 
     @BeforeEach
     void setUp() {
-        member = memberRepository.save(아마란스());
+        leader = memberRepository.save(아마란스());
+        member = memberRepository.save(보름());
         study = studyRepository.save(algorithmStudy());
         studyRole = studyRoleRepository.save(StudyRole.builder()
                 .studyRoleType(StudyRoleType.ROLE_스터디장)
                 .studyId(study.getId())
-                .memberId(member.getId())
+                .memberId(leader.getId())
                 .build());
     }
 
@@ -61,7 +64,7 @@ public class ParticipantQueryTest extends IntegrationTest {
         @DisplayName("[성공] 참여자를 정상적으로 조회할 수 있다.")
         void getParticipants_참여자를_정상적으로_조회할_수_있다_성공() {
             //given
-            participantCommandService.createParticipant(study.getId(), member.getId(), member.getId());
+            participantCommandService.createParticipant(study.getId(), member.getId(), leader.getId());
 
             //when
             final List<ParticipantResponse> participantResponses = participantQueryService.getParticipants(study.getId(),
@@ -77,8 +80,6 @@ public class ParticipantQueryTest extends IntegrationTest {
         @Test
         @DisplayName("[실패] 스터디_구성원이 아니라면 참여자를 조회할 수 없다.")
         void getParticipants_스터디_구성원이_아니라면_참여자를_조회할_수_없다_실패() throws Exception {
-            final Member member = memberRepository.save(보름());
-
             assertThatThrownBy(() -> participantQueryService.getParticipants(study.getId(), member.getId()))
                     .isInstanceOf(MemberException.class)
                     .hasMessage(UNAUTHORIZED.errorMessage());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #240 

## 📝 작업 내용

- 스터디원을 초대 시 중복 검사를 초대해서 동일한 맴버가 여러번 초대될 수 없도록 수정하였습니다.

## 💬 리뷰 요구사항(선택)

- 팀 가입 시 중복 검사하는 로직이 있어 참고해서 개발하였습니다!