### PR TITLE
Feature/#248 팀장이 팀페이지에서 스터디장을 삭제할 시 어떤 스터디의 스터디장인지 전달

### DIFF
--- a/src/main/java/doore/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/doore/member/application/convenience/MemberConvenience.java
@@ -1,7 +1,10 @@
 package doore.member.application.convenience;
 
+import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 
+import doore.member.domain.Member;
+import doore.member.domain.repository.MemberRepository;
 import doore.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,10 +14,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class MemberConvenience {
+    private final MemberRepository memberRepository;
 
     public void checkSameMemberIdAndTokenMemberId(final Long memberId, final Long tokenMemberId) {
         if (!memberId.equals(tokenMemberId)) {
             throw new MemberException(UNAUTHORIZED);
         }
+    }
+
+    public Member findByMember(final Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
@@ -50,11 +50,16 @@ public class StudyRoleConvenience {
     }
 
     public void isStudyLeader(final List<Study> studies, final Long memberId) {
-        boolean isStudyLeader = studies.stream().anyMatch(
-                study -> studyRoleRepository.existsByStudyIdAndMemberIdAndStudyRoleType(study.getId(), memberId,
-                        ROLE_스터디장));
-        if (isStudyLeader) {
-            throw new MemberException(CANNOT_DELETE_STUDY_LEADER);
+        final List<String> leaderStudyNames = studies.stream()
+                .filter(study -> studyRoleRepository.existsByStudyIdAndMemberIdAndStudyRoleType(
+                        study.getId(), memberId, ROLE_스터디장))
+                .map(Study::getName)
+                .toList();
+
+        if (!leaderStudyNames.isEmpty()) {
+            String joinedNames = String.join(", ", leaderStudyNames);
+            String formattedMessage = String.format(CANNOT_DELETE_STUDY_LEADER.errorMessage(), joinedNames);
+            throw new MemberException(CANNOT_DELETE_STUDY_LEADER, formattedMessage);
         }
     }
 

--- a/src/main/java/doore/member/exception/MemberException.java
+++ b/src/main/java/doore/member/exception/MemberException.java
@@ -11,6 +11,11 @@ public class MemberException extends BaseException {
         this.exceptionType = exceptionType;
     }
 
+    public MemberException(final MemberExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
     @Override
     public BaseExceptionType exceptionType() {
         return exceptionType;

--- a/src/main/java/doore/member/exception/MemberExceptionType.java
+++ b/src/main/java/doore/member/exception/MemberExceptionType.java
@@ -12,7 +12,7 @@ public enum MemberExceptionType implements BaseExceptionType {
     NOT_FOUND_MEMBER_IN_STUDY(HttpStatus.NOT_FOUND, "스터디 내 해당 회원을 찾을 수 없습니다."),
     ALREADY_JOIN_TEAM_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 팀원입니다."),
     ALREADY_JOIN_STUDY_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 스터디원입니다."),
-    CANNOT_DELETE_STUDY_LEADER(HttpStatus.BAD_REQUEST, "스터디장을 맡고 있다면 팀원 삭제가 불가능합니다."),
+    CANNOT_DELETE_STUDY_LEADER(HttpStatus.BAD_REQUEST, "스터디장을 맡고 있다면 팀원 삭제가 불가능합니다.(%s)"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -3,6 +3,7 @@ package doore.study.application;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.member.exception.ParticipantExceptionType.CANNOT_DELETE_STUDY_LEADER_SELF;
 
+import doore.member.application.convenience.MemberConvenience;
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleConvenience;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
@@ -28,6 +29,7 @@ public class ParticipantCommandService {
     private final StudyRoleConvenience studyRoleConvenience;
     private final ParticipantConvenience participantConvenience;
     private final StudyConvenience studyConvenience;
+    private final MemberConvenience memberConvenience;
 
     private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
     private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
@@ -79,8 +81,10 @@ public class ParticipantCommandService {
 
     private void assignStudyLeaderToTeamLeader(final Long studyId, final Long deleteMemberId, final Long teamId,
                                                final Long leaderId) {
+        Member leader = memberConvenience.findByMember(leaderId);
         if (studyRoleValidateAccessPermission.isStudyLeader(studyId, deleteMemberId)
                 && teamRoleValidateAccessPermission.isTeamLeader(teamId, leaderId)) {
+            participantConvenience.assignParticipant(studyId, leader);
             studyRoleConvenience.assignStudyLeaderRole(studyId, leaderId);
         }
     }

--- a/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
@@ -159,8 +159,10 @@ public class MemberTeamCommandServiceTest extends IntegrationTest {
                 .memberId(studyLeaderMember.getId())
                 .build());
 
+        final String expectedMessage = String.format(CANNOT_DELETE_STUDY_LEADER.errorMessage(), "알고리즘");
+
         assertThatThrownBy(() -> {
             memberTeamCommandService.deleteMemberTeam(team.getId(), studyLeaderMember.getId(), teamLeader.getId());
-        }).isInstanceOf(MemberException.class).hasMessage(CANNOT_DELETE_STUDY_LEADER.errorMessage());
+        }).isInstanceOf(MemberException.class).hasMessage(expectedMessage);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #248
close: #249 

## 📝 작업 내용

- 프론트의 요구사항에 맞게 팀장이 팀페이지에서 스터디장을 삭제할 때 어떤 스터디의 스터디장인지 전달하는 기능을 개발했습니다!
- 그리고 팀장이 스터디장을 삭제한 후 그 스터디의 스터디장이 되도록 구현했는데 참여자에는 저장하지 않아서 스터디장 위임 후 오류가 발생하는 문제가 있었습니다. 해당 문제를 해결하였습니다.

## 💬 리뷰 요구사항

- 원래 스터디장 스터디 정보를 response를 통해 주려고 했는데, 예외처리가 되면 메서드가 끝나버려 response형태로 주는 것보다 error message 형태가 더 좋을 것 같아 error message로 정보를 주도록 변경했는데 확인 한 번 부탁드립니다!
