### PR TITLE
Feature/#250 팀 이미지 삭제 기능 구현

### DIFF
--- a/src/docs/asciidoc/team.adoc
+++ b/src/docs/asciidoc/team.adoc
@@ -56,6 +56,17 @@ include::{snippets}/team-image-update/request-parts.adoc[]
 .HTTP Response
 include::{snippets}/team-image-update/http-response.adoc[]
 
+== `DELETE`: Team 이미지 삭제
+
+.HTTP Request
+include::{snippets}/team-image-delete/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/team-image-delete/path-parameters.adoc[]
+
+.HTTP Response
+include::{snippets}/team-image-delete/http-response.adoc[]
+
 == `DELETE`: Team 삭제
 
 .HTTP Request

--- a/src/main/java/doore/team/api/TeamController.java
+++ b/src/main/java/doore/team/api/TeamController.java
@@ -69,6 +69,13 @@ public class TeamController {
         return ResponseEntity.noContent().build();
     }
 
+    @DeleteMapping("/{teamId}/image") // 팀장
+    public ResponseEntity<Void> deleteTeamImage(@PathVariable final Long teamId, @LoginMember final Member member
+    ) {
+        teamCommandService.deleteTeamImage(teamId, member.getId());
+        return ResponseEntity.noContent().build();
+    }
+
     @DeleteMapping("/{teamId}") // 팀장
     public ResponseEntity<Void> deleteTeam(@PathVariable final Long teamId, @LoginMember final Member member) {
         teamCommandService.deleteTeam(teamId, member.getId());

--- a/src/main/java/doore/team/application/TeamCommandService.java
+++ b/src/main/java/doore/team/application/TeamCommandService.java
@@ -88,24 +88,25 @@ public class TeamCommandService {
     public void updateTeamImage(final Long teamId, final MultipartFile file, final Long memberId) {
         teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, memberId);
         final Team team = teamValidateAccessPermission.getValidateExistTeam(teamId);
-
-        if (team.hasImage()) {
-            final String beforeImageUrl = team.getImageUrl();
-            s3ImageFileService.deleteFile(beforeImageUrl);
-        }
+        checkHasImageAndDelete(team);
 
         final String newImageUrl = s3ImageFileService.upload(file);
         team.updateImageUrl(newImageUrl);
+    }
+
+    public void deleteTeamImage(final Long teamId, final Long memberId) {
+        final Team team = teamValidateAccessPermission.getValidateExistTeam(teamId);
+        teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, memberId);
+        checkHasImageAndDelete(team);
+
+        team.updateImageUrl(DEFAULT_IMAGE_URL);
     }
 
     public void deleteTeam(final Long teamId, final Long memberId) {
         teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, memberId);
         final Team team = teamValidateAccessPermission.getValidateExistTeam(teamId);
         teamRepository.delete(team);
-
-        if (team.hasImage()) {
-            s3ImageFileService.deleteFile(team.getImageUrl());
-        }
+        checkHasImageAndDelete(team);
 
         deleteMemberTeamAndParticipant(teamId);
         deleteStudyAndCurriculumItemAndParticipantCurriculumItem(teamId);
@@ -171,5 +172,11 @@ public class TeamCommandService {
                 participantCurriculumItems.forEach(ParticipantCurriculumItem::delete); // todo: 수료증 개발 시 delete 로직 확인 필요
             });
         });
+    }
+
+    private void checkHasImageAndDelete(final Team team) {
+        if (team.hasImage()) {
+            s3ImageFileService.deleteFile(team.getImageUrl());
+        }
     }
 }

--- a/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/TeamApiDocsTest.java
@@ -144,6 +144,23 @@ public class TeamApiDocsTest extends RestDocsTest {
     }
 
     @Test
+    @DisplayName("팀의 이미지를 삭제한다.")
+    public void 팀의_이미지를_삭제한다() throws Exception {
+        // when
+        final Long teamId = 1L;
+        doNothing().when(teamCommandService).deleteTeamImage(eq(teamId), any());
+
+        // then
+        final PathParametersSnippet pathParameters = pathParameters(
+                parameterWithName("teamId").description("팀 ID")
+        );
+        mockMvc.perform(delete("/teams/{teamId}/image", teamId)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken))
+                .andExpect(status().isNoContent())
+                .andDo(document("team-image-delete", pathParameters));
+    }
+
+    @Test
     @DisplayName("팀을 삭제한다.")
     public void 팀을_삭제한다() throws Exception {
         // when


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #250

## 📝 작업 내용

- 팀 이미지 삭제 기능을 구현했습니다!

## 💬 리뷰 요구사항

- 이미지가 삭제되면 이미지 주소는 default 주소로 바뀌도록 해두었습니당