### PR TITLE
Feature/#251 팀원 본인 탈퇴 기능 구현

### DIFF
--- a/src/docs/asciidoc/memberTeam.adoc
+++ b/src/docs/asciidoc/memberTeam.adoc
@@ -37,3 +37,13 @@ include::{snippets}/member-team-delete/path-parameters.adoc[]
 
 .HTTP Response
 include::{snippets}/member-team-delete/http-response.adoc[]
+
+== `DELETE`: 팀원 탈퇴
+.HTTP Request
+include::{snippets}/member-team-withdraw/http-request.adoc[]
+
+.Query Parameters
+include::{snippets}/member-team-withdraw/path-parameters.adoc[]
+
+.HTTP Response
+include::{snippets}/member-team-withdraw/http-response.adoc[]

--- a/src/docs/asciidoc/participant.adoc
+++ b/src/docs/asciidoc/participant.adoc
@@ -44,9 +44,6 @@ include::{snippets}/participant-withdraw/http-request.adoc[]
 .Path Parameters
 include::{snippets}/participant-withdraw/path-parameters.adoc[]
 
-.Request Header
-include::{snippets}/participant-withdraw/request-headers.adoc[]
-
 .HTTP Response
 include::{snippets}/participant-withdraw/http-response.adoc[]
 

--- a/src/main/java/doore/member/api/MemberTeamController.java
+++ b/src/main/java/doore/member/api/MemberTeamController.java
@@ -36,4 +36,10 @@ public class MemberTeamController {
         memberTeamCommandService.deleteMemberTeam(teamId, deleteMemberId, member.getId());
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/teams/{teamId}/members") // 팀원
+    public ResponseEntity<Void> withdrawMemberTeam(@PathVariable final Long teamId, @LoginMember final Member member) {
+        memberTeamCommandService.withdrawMemberTeam(teamId, member.getId());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/doore/member/application/MemberTeamCommandService.java
+++ b/src/main/java/doore/member/application/MemberTeamCommandService.java
@@ -35,9 +35,17 @@ public class MemberTeamCommandService {
         checkIsEqualDeleteMemberIdAndTeamLeaderId(deleteMemberId, teamLeaderId);
         teamRoleValidateAccessPermission.validateExistTeamLeader(teamId, teamLeaderId);
         teamRoleValidateAccessPermission.validateExistMemberTeam(teamId, deleteMemberId);
-        deleteStudiesAndParticipants(teamId, deleteMemberId);
+        deleteStudyRoleAndParticipants(teamId, deleteMemberId);
         memberTeamRepository.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
         teamRoleConvenience.deleteByTeamIdAndMemberId(teamId, deleteMemberId);
+    }
+
+    public void withdrawMemberTeam(final Long teamId, final Long memberId) {
+        teamValidateAccessPermission.validateExistTeam(teamId);
+        teamRoleValidateAccessPermission.validateExistTeamMember(teamId, memberId);
+        deleteStudyRoleAndParticipants(teamId, memberId);
+        memberTeamRepository.deleteByTeamIdAndMemberId(teamId, memberId);
+        teamRoleConvenience.deleteByTeamIdAndMemberId(teamId, memberId);
     }
 
     private void checkIsEqualDeleteMemberIdAndTeamLeaderId(final Long deleteMemberId, final Long teamLeaderId) {
@@ -46,7 +54,7 @@ public class MemberTeamCommandService {
         }
     }
 
-    private void deleteStudiesAndParticipants(final Long teamId, final Long deleteMemberId) {
+    private void deleteStudyRoleAndParticipants(final Long teamId, final Long deleteMemberId) {
         List<Study> studies = studyConvenience.findAllByTeamIdAndMemberId(teamId, deleteMemberId);
         studyRoleConvenience.isStudyLeader(studies, deleteMemberId);
 

--- a/src/main/java/doore/member/application/MemberTeamCommandService.java
+++ b/src/main/java/doore/member/application/MemberTeamCommandService.java
@@ -42,7 +42,7 @@ public class MemberTeamCommandService {
 
     public void withdrawMemberTeam(final Long teamId, final Long memberId) {
         teamValidateAccessPermission.validateExistTeam(teamId);
-        teamRoleValidateAccessPermission.validateExistTeamMember(teamId, memberId);
+        teamRoleValidateAccessPermission.validateExistMemberTeamOnly(teamId, memberId);
         deleteStudyRoleAndParticipants(teamId, memberId);
         memberTeamRepository.deleteByTeamIdAndMemberId(teamId, memberId);
         teamRoleConvenience.deleteByTeamIdAndMemberId(teamId, memberId);

--- a/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
@@ -1,5 +1,6 @@
 package doore.member.application.convenience;
 
+import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.member.domain.StudyRoleType.ROLE_스터디장;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
@@ -34,7 +35,15 @@ public class StudyRoleValidateAccessPermission {
         return studyRole;
     }
 
-    public void validateExistParticipant(final Long studyId, final Long memberId) {
+    public void validateExistParticipantOnly(final Long studyId, final Long memberId) { // Only 스터디원인지 확인. Not 스터디
+        final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
+        if (!studyRole.getStudyRoleType().equals(ROLE_스터디원)) {
+            throw new MemberException(UNAUTHORIZED);
+        }
+    }
+
+    public void validateExistParticipant(final Long studyId, final Long memberId) { // Both 스터디원 and 스터디장
         studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
                 .orElseThrow(() -> new MemberException(UNAUTHORIZED));
     }

--- a/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleValidateAccessPermission.java
@@ -35,7 +35,7 @@ public class StudyRoleValidateAccessPermission {
         return studyRole;
     }
 
-    public void validateExistParticipantOnly(final Long studyId, final Long memberId) { // Only 스터디원인지 확인. Not 스터디
+    public void validateExistParticipantOnly(final Long studyId, final Long memberId) { // Only 스터디원인지 확인. Not 스터디장
         final StudyRole studyRole = studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_STUDY));
         if (!studyRole.getStudyRoleType().equals(ROLE_스터디원)) {

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -1,5 +1,6 @@
 package doore.member.application.convenience;
 
+import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_TEAM;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
@@ -34,7 +35,15 @@ public class TeamRoleValidateAccessPermission {
         return teamRole;
     }
 
-    public void validateExistMemberTeam(final Long teamId, final Long memberId) {
+    public void validateExistTeamMember(final Long teamId, final Long memberId) { // Only 팀원인지 확인. Not 팀장
+        final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
+        if (!teamRole.getTeamRoleType().equals(ROLE_팀원)) {
+            throw new MemberException(UNAUTHORIZED);
+        }
+    }
+
+    public void validateExistMemberTeam(final Long teamId, final Long memberId) { // Both 팀원 and 팀장
         teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
                 .orElseThrow(() -> new MemberException(UNAUTHORIZED));
     }

--- a/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleValidateAccessPermission.java
@@ -35,7 +35,7 @@ public class TeamRoleValidateAccessPermission {
         return teamRole;
     }
 
-    public void validateExistTeamMember(final Long teamId, final Long memberId) { // Only 팀원인지 확인. Not 팀장
+    public void validateExistMemberTeamOnly(final Long teamId, final Long memberId) { // Only 팀원인지 확인. Not 팀장
         final TeamRole teamRole = teamRoleRepository.findTeamRoleByTeamIdAndMemberId(teamId, memberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ROLE_IN_TEAM));
         if (!teamRole.getTeamRoleType().equals(ROLE_팀원)) {

--- a/src/main/java/doore/study/api/ParticipantController.java
+++ b/src/main/java/doore/study/api/ParticipantController.java
@@ -38,7 +38,7 @@ public class ParticipantController {
     @DeleteMapping("/studies/{studyId}/members") // 스터디원
     public ResponseEntity<Void> withdrawParticipant(@PathVariable final Long studyId,
                                                     @LoginMember final Member member) {
-        participantCommandService.withdrawParticipant(studyId, member.getId(), member.getId());
+        participantCommandService.withdrawParticipant(studyId, member.getId());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -53,9 +53,9 @@ public class ParticipantCommandService {
         studyRoleConvenience.deleteByStudyIdAndMemberId(studyId, memberId);
     }
 
-    public void withdrawParticipant(final Long studyId, final Long memberId, final Long participantId) {
-        studyRoleValidateAccessPermission.validateExistParticipant(studyId, participantId);
+    public void withdrawParticipant(final Long studyId, final Long memberId) {
         studyValidateAccessPermission.validateExistStudy(studyId);
+        studyRoleValidateAccessPermission.validateExistParticipantOnly(studyId, memberId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         participantRepository.deleteByStudyIdAndMember(studyId, member);
         studyRoleConvenience.deleteByStudyIdAndMemberId(studyId, memberId);

--- a/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
@@ -163,4 +163,25 @@ public class MemberTeamCommandServiceTest extends IntegrationTest {
             memberTeamCommandService.deleteMemberTeam(team.getId(), studyLeaderMember.getId(), teamLeader.getId());
         }).isInstanceOf(MemberException.class).hasMessage(CANNOT_DELETE_STUDY_LEADER.errorMessage());
     }
+
+    @Test
+    @DisplayName("[성공] 팀원은 정상적으로 스스로 탈퇴할 수 있다.")
+    public void withdrawMemberTeam_팀원은_정상적으로_스스로_탈퇴할_수_있다_성공() throws Exception {
+        long memberCount = memberTeamRepository.countByTeamId(team.getId());
+
+        //when
+        memberTeamCommandService.withdrawMemberTeam(team.getId(), teamMember.getId());
+
+        //then
+        long resultMemberCount = memberTeamRepository.countByTeamId(team.getId());
+        assertThat(resultMemberCount).isEqualTo(memberCount - 1);
+    }
+
+    @Test
+    @DisplayName("[실패] 팀장은 스스로 탈퇴할 수 없다.")
+    public void withdrawMemberTeam_팀장은_스스로_탈퇴할_수_없다_실패() throws Exception {
+        assertThatThrownBy(() -> {
+            memberTeamCommandService.withdrawMemberTeam(team.getId(), teamLeader.getId());
+        }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
+    }
 }

--- a/src/test/java/doore/restdocs/docs/MemberTeamApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/MemberTeamApiDocsTest.java
@@ -116,4 +116,18 @@ public class MemberTeamApiDocsTest extends RestDocsTest {
                         parameterWithName("teamId").description("팀 id"),
                         parameterWithName("memberId").description("삭제할 멤버 id"))));
     }
+
+    @Test
+    @DisplayName("팀원이 스스로 탈퇴할 수 있다.")
+    public void 팀원이_스스로_탈퇴할_수_있다() throws Exception {
+        //when
+        doNothing().when(memberTeamCommandService).withdrawMemberTeam(any(), any());
+
+        //then
+        mockMvc.perform(delete("/teams/{teamId}/members", 1)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent())
+                .andDo(document("member-team-withdraw", pathParameters(
+                        parameterWithName("teamId").description("팀 id"))));
+    }
 }

--- a/src/test/java/doore/restdocs/docs/ParticipantApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/ParticipantApiDocsTest.java
@@ -2,8 +2,6 @@ package doore.restdocs.docs;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -61,8 +59,7 @@ public class ParticipantApiDocsTest extends RestDocsTest {
                         .header(HttpHeaders.AUTHORIZATION, accessToken))
                 .andExpect(status().isNoContent())
                 .andDo(document("participant-withdraw",
-                        pathParameters(parameterWithName("studyId").description("스터디 id")),
-                        requestHeaders(headerWithName("Authorization").description("member id"))
+                        pathParameters(parameterWithName("studyId").description("스터디 id"))
                 ));
     }
 

--- a/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
+++ b/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
@@ -188,7 +188,7 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
             participantCommandService.createParticipant(studyId, participant.getId(), member.getId());
 
             //when
-            participantCommandService.withdrawParticipant(studyId, participant.getId(), participant.getId());
+            participantCommandService.withdrawParticipant(studyId, participant.getId());
 
             //then
             assertThat(participantRepository.findByMemberId(participant.getId()).get(0).getIsDeleted()).isEqualTo(true);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #251 

## 📝 작업 내용

- 팀원 스스로 탈퇴하는 기능 구현
- 스터디원 스스로 탈퇴하는 기능에 대해 스터디장 & 스터디원이 가능했던 부분을 스터디원만 가능하도록 수정

## 💬 리뷰 요구사항

- 원래 팀원(MemberTeam)은 팀장과 팀원을 모두 통칭하는 말이며, 스터디원(participant)는 스터디장과 스터디원을 통칭하는 말입니다. 하지만 팀장과 스터디장은 그 직위를 가지고 있다면 탈퇴가 불가능하게 설계되어있으므로(유령팀, 유령스터디 방지) 탈퇴 api는 팀원, 스터디원만의 기능이 되도록 구현해야 했습니다. 따라서 메서드 이름을 뒤에 (Only)를 붙여서 구분하였습니다!
- 혹시 헷갈릴까봐 주석 추가해두었습니다~!
