### PR TITLE
Feature/#252 학습자료 전체 조회에서 최신순으로 정렬하는 기능

### DIFF
--- a/src/main/java/doore/document/api/DocumentController.java
+++ b/src/main/java/doore/document/api/DocumentController.java
@@ -14,6 +14,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -58,7 +59,7 @@ public class DocumentController {
             @RequestParam(defaultValue = "4") @PositiveOrZero final int size) {
         final DocumentGroupType group = DocumentGroupType.value(groupType);
         final Page<DocumentResponse> documents =
-                documentQueryService.getAllDocument(group, groupId, PageRequest.of(page, size));
+                documentQueryService.getAllDocument(group, groupId, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
         return ResponseEntity.status(HttpStatus.OK).body(documents);
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close: #252 

## 📝 작업 내용

> 학습자료 전체 조회 시 최신순으로 자료를 가져오도록 변경

## 💬 리뷰 요구사항

> Document Pageable에서 createdAt 기준으로 내림차순 정렬하는 간단한 수정입니다
