### PR TITLE
Feature/#253 학습자료 파일명 및 다운로드 기능 구현

### DIFF
--- a/src/docs/asciidoc/doore.adoc
+++ b/src/docs/asciidoc/doore.adoc
@@ -20,6 +20,8 @@ link:./attendance.html[출석 API]
 
 link:./document.html[학습자료 API]
 
+link:./file.html[파일 API]
+
 link:./garden.html[텃밭 API]
 
 ## 스터디

--- a/src/docs/asciidoc/file.adoc
+++ b/src/docs/asciidoc/file.adoc
@@ -1,0 +1,46 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= DOCUMENT API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+
+== API 목록
+
+link:../doore.html[API 목록으로 돌아가기]
+
+
+== `GET`: 이미지 파일 URL 조회
+
+.Http Request
+include::{snippets}/file-get-image-url/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/file-get-image-url/path-parameters.adoc[]
+
+.Http Response
+include::{snippets}/file-get-image-url/http-response.adoc[]
+
+.Http Response Headers
+include::{snippets}/file-get-image-url/response-headers.adoc[]
+
+
+== `GET`: 문서 파일 Presigned URL 생성
+
+.Http Request
+include::{snippets}/file-generate-presigned-url/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/file-generate-presigned-url/path-parameters.adoc[]
+
+.Http Response
+include::{snippets}/file-generate-presigned-url/http-response.adoc[]
+
+.Http Response Headers
+include::{snippets}/file-generate-presigned-url/response-headers.adoc[]

--- a/src/docs/asciidoc/file.adoc
+++ b/src/docs/asciidoc/file.adoc
@@ -15,7 +15,6 @@ endif::[]
 
 link:../doore.html[API 목록으로 돌아가기]
 
-
 == `GET`: 이미지 파일 URL 조회
 
 .Http Request
@@ -29,7 +28,6 @@ include::{snippets}/file-get-image-url/http-response.adoc[]
 
 .Http Response Headers
 include::{snippets}/file-get-image-url/response-headers.adoc[]
-
 
 == `GET`: 문서 파일 Presigned URL 생성
 

--- a/src/main/java/doore/config/S3Config.java
+++ b/src/main/java/doore/config/S3Config.java
@@ -18,13 +18,16 @@ public class S3Config {
     @Value("${aws.credentials.secret-key}")
     private String secretKey;
 
+    @Value("${aws.region}")
+    private String region;
+
     @Bean
     public AmazonS3Client amazonS3Client() {
         BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
 
         return (AmazonS3Client) AmazonS3ClientBuilder
                 .standard()
-                .withRegion(Regions.AP_NORTHEAST_2)
+                .withRegion(Regions.fromName(region))
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .build();
     }

--- a/src/main/java/doore/document/application/DocumentCommandService.java
+++ b/src/main/java/doore/document/application/DocumentCommandService.java
@@ -59,7 +59,7 @@ public class DocumentCommandService {
         if (!document.getType().equals(DocumentType.URL)) {
             final List<File> newFiles = new ArrayList<>();
             for (MultipartFile file : multipartFiles) {
-                final String filename = file.getName();
+                final String filename = file.getOriginalFilename();
                 final String filePath = uploadFileToS3(document.getType(), file);
                 final File newFile = createFile(filePath, filename, document);
                 newFiles.add(newFile);

--- a/src/main/java/doore/file/api/FileController.java
+++ b/src/main/java/doore/file/api/FileController.java
@@ -1,0 +1,39 @@
+package doore.file.api;
+
+import doore.file.application.S3DocumentFileService;
+import doore.file.application.S3ImageFileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class FileController {
+    private final S3ImageFileService s3ImageFileService;
+    private final S3DocumentFileService s3DocumentFileService;
+
+    @GetMapping("/files/images/{uuid}")
+    public ResponseEntity<Void> imageFile(@PathVariable String uuid) {
+        String imageUrl = s3ImageFileService.getS3Url(uuid);
+
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+            .header("Location", imageUrl)
+            .build();
+    }
+
+    @GetMapping("/files/documents/{uuid}")
+    public ResponseEntity<Void> documentFile(@PathVariable String uuid) {
+        String presignedUrl = s3DocumentFileService.generatePresignedUrl(uuid);
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+            .header("Location", presignedUrl)
+            .build();
+    }
+}

--- a/src/main/java/doore/file/api/FileController.java
+++ b/src/main/java/doore/file/api/FileController.java
@@ -5,35 +5,33 @@ import doore.file.application.S3ImageFileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping
+@RequestMapping("/files")
 public class FileController {
     private final S3ImageFileService s3ImageFileService;
     private final S3DocumentFileService s3DocumentFileService;
 
-    @GetMapping("/files/images/{uuid}")
-    public ResponseEntity<Void> imageFile(@PathVariable String uuid) {
-        String imageUrl = s3ImageFileService.getS3Url(uuid);
+    @GetMapping("/images/{uuid}")
+    public ResponseEntity<Void> getImageUrl(@PathVariable String uuid) {
+        final String imageUrl = s3ImageFileService.getS3Url(uuid);
 
         return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
-            .header("Location", imageUrl)
-            .build();
+                .header("Location", imageUrl)
+                .build();
     }
 
-    @GetMapping("/files/documents/{uuid}")
-    public ResponseEntity<Void> documentFile(@PathVariable String uuid) {
-        String presignedUrl = s3DocumentFileService.generatePresignedUrl(uuid);
+    @GetMapping("/documents/{uuid}")
+    public ResponseEntity<Void> getDocumentUrl(@PathVariable String uuid) {
+        final String presignedUrl = s3DocumentFileService.generatePresignedUrl(uuid);
 
         return ResponseEntity.status(HttpStatus.FOUND)
-            .header("Location", presignedUrl)
-            .build();
+                .header("Location", presignedUrl)
+                .build();
     }
 }

--- a/src/main/java/doore/file/application/S3FileService.java
+++ b/src/main/java/doore/file/application/S3FileService.java
@@ -3,15 +3,19 @@ package doore.file.application;
 import static doore.file.exception.FileExceptionType.FILE_IS_NULL;
 import static doore.file.exception.FileExceptionType.INVALID_FILE_ACCESS;
 
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.ResponseHeaderOverrides;
 import doore.file.exception.FileException;
 import doore.file.exception.FileExceptionType;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -31,12 +35,18 @@ public abstract class S3FileService {
     @Value("${aws.s3.bucket}")
     protected String bucket;
 
+    @Value("${aws.s3.baseUrl}")
+    protected String baseUrl;
+
     public String upload(final MultipartFile file) {
         validateNotNull(file);
 
         final String fileExtension = getFileExtension(file);
+        final String originalFileName = Objects.requireNonNull(file.getOriginalFilename());
         final String newFileName = createFileName(fileExtension);
         final ObjectMetadata objectMetadata = getObjectMetadata(file);
+
+        objectMetadata.addUserMetadata("original-file-name", originalFileName);
 
         try (final InputStream inputStream = file.getInputStream()) {
             amazonS3.putObject(new PutObjectRequest(bucket, newFileName, inputStream, objectMetadata));
@@ -86,5 +96,26 @@ public abstract class S3FileService {
     public void deleteFile(final String fileName) {
         final String decodedFileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
         amazonS3.deleteObject(bucket, decodedFileName);
+    }
+
+    public String getS3Url(String fileName) {
+        return String.format("%s/%s", baseUrl, getFileFolder() + fileName);
+    }
+
+    public String generatePresignedUrl(String fileName) {
+        ObjectMetadata metadata = amazonS3.getObjectMetadata(bucket, getFileFolder() + fileName);
+        String originalFileName = metadata.getUserMetaDataOf("original-file-name");
+
+        Date expiration = new Date();
+        expiration.setTime(System.currentTimeMillis() + 1000 * 60 * 60);
+
+        ResponseHeaderOverrides headerOverrides = new ResponseHeaderOverrides();
+        headerOverrides.setContentDisposition("attachment; filename=\"" + originalFileName + "\"");
+        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, getFileFolder() + fileName)
+            .withMethod(HttpMethod.GET)
+            .withExpiration(expiration)
+            .withResponseHeaders(headerOverrides);
+
+        return amazonS3.generatePresignedUrl(request).toString();
     }
 }

--- a/src/main/java/doore/file/application/S3FileService.java
+++ b/src/main/java/doore/file/application/S3FileService.java
@@ -112,9 +112,9 @@ public abstract class S3FileService {
         ResponseHeaderOverrides headerOverrides = new ResponseHeaderOverrides();
         headerOverrides.setContentDisposition("attachment; filename=\"" + originalFileName + "\"");
         GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, getFileFolder() + fileName)
-            .withMethod(HttpMethod.GET)
-            .withExpiration(expiration)
-            .withResponseHeaders(headerOverrides);
+                .withMethod(HttpMethod.GET)
+                .withExpiration(expiration)
+                .withResponseHeaders(headerOverrides);
 
         return amazonS3.generatePresignedUrl(request).toString();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,11 +2,11 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/doore
     username: root
-    password: 1234
+    password: bdd@2024
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql:
     init:
-      mode: always
+      mode: never
   jpa:
     hibernate:
       ddl-auto: none
@@ -59,3 +59,6 @@ aws:
   credentials:
     access-key: test
     secret-key: test
+
+server:
+  port: 8000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,11 +2,11 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/doore
     username: root
-    password: bdd@2024
+    password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql:
     init:
-      mode: never
+      mode: always
   jpa:
     hibernate:
       ddl-auto: none
@@ -46,7 +46,7 @@ jwt:
 
 cors:
   allow:
-    origins: https://www.doore.kro.kr
+    origins: https://doore.pnu.app
     methods: GET, POST, PUT, DELETE, PATCH, OPTION
 
 aws:
@@ -59,6 +59,4 @@ aws:
   credentials:
     access-key: test
     secret-key: test
-
-server:
-  port: 8000
+  region: ap-northeast-2

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,7 @@ cors:
 aws:
   s3:
     bucket: test
+    baseUrl: https://s3.url
     folder:
       imageFolder: images/
       documentFolder: documents/

--- a/src/test/java/doore/restdocs/RestDocsTest.java
+++ b/src/test/java/doore/restdocs/RestDocsTest.java
@@ -10,6 +10,9 @@ import doore.config.WebMvcConfig;
 import doore.document.api.DocumentController;
 import doore.document.application.DocumentCommandService;
 import doore.document.application.DocumentQueryService;
+import doore.file.api.FileController;
+import doore.file.application.S3DocumentFileService;
+import doore.file.application.S3ImageFileService;
 import doore.garden.api.GardenController;
 import doore.garden.application.GardenQueryService;
 import doore.helper.ApiTestHelper;
@@ -19,8 +22,8 @@ import doore.login.utils.JwtTokenGenerator;
 import doore.member.api.MemberController;
 import doore.member.api.MemberTeamController;
 import doore.member.application.MemberCommandService;
-import doore.member.application.MemberTeamCommandService;
 import doore.member.application.MemberQueryService;
+import doore.member.application.MemberTeamCommandService;
 import doore.member.application.MemberTeamQueryService;
 import doore.member.domain.repository.MemberRepository;
 import doore.study.api.CurriculumItemController;
@@ -63,6 +66,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
         LoginController.class,
         MemberController.class,
         GardenController.class,
+        FileController.class,
 })
 public abstract class RestDocsTest extends ApiTestHelper {
 
@@ -71,6 +75,12 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockBean
     protected DocumentCommandService documentCommandService;
+
+    @MockBean
+    protected S3ImageFileService s3ImageFileService;
+
+    @MockBean
+    protected S3DocumentFileService s3DocumentFileService;
 
     @MockBean
     protected CurriculumItemCommandService curriculumItemCommandService;

--- a/src/test/java/doore/restdocs/docs/FileDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/FileDocsTest.java
@@ -17,39 +17,39 @@ public class FileDocsTest extends RestDocsTest {
 
     @Test
     @DisplayName("[성공] 이미지 파일의 URL을 조회한다.")
-    public void 이미지_파일_URL_조회() throws Exception {
+    public void 이미지_파일_URL_조회한다_성공() throws Exception {
         String uuid = "8a463aa4-b1dc-4f27-9c3f-53b94dc45e74.jpg";
         String s3Url = "https://s3.amazonaws.com/my-bucket/images/" + uuid;
         when(s3ImageFileService.getS3Url(uuid)).thenReturn(s3Url);
 
         mockMvc.perform(get("/files/images/{uuid}", uuid))
-            .andExpect(status().isMovedPermanently())
-            .andDo(document("file-get-image-url",
-                pathParameters(
-                    parameterWithName("uuid").description("이미지 파일의 UUID")
-                ),
-                responseHeaders(
-                    headerWithName("Location").description("S3에서 제공되는 Public URL")
-                )
-            ));
+                .andExpect(status().isMovedPermanently())
+                .andDo(document("file-get-image-url",
+                        pathParameters(
+                                parameterWithName("uuid").description("이미지 파일의 UUID")
+                        ),
+                        responseHeaders(
+                                headerWithName("Location").description("S3에서 제공되는 Public URL")
+                        )
+                ));
     }
 
     @Test
-    @DisplayName("[성공] 문서 파일의 Presigned URL을 생성한다.")
-    public void 문서_파일_Presigned_URL_생성() throws Exception {
+    @DisplayName("[성공] 문서 파일의 Presigned URL을 생성")
+    public void 문서_파일_Presigned_URL_생성한다_성공() throws Exception {
         String uuid = "8a463aa4-b1dc-4f27-9c3f-53b94dc45e74.pdf";
         String presignedUrl = "https://s3.amazonaws.com/my-bucket/documents/" + uuid + "?signature=123";
         when(s3DocumentFileService.generatePresignedUrl(uuid)).thenReturn(presignedUrl);
 
         mockMvc.perform(get("/files/documents/{uuid}", uuid))
-            .andExpect(status().isFound())
-            .andDo(document("file-generate-presigned-url",
-                pathParameters(
-                    parameterWithName("uuid").description("Presigned URL을 생성할 문서의 UUID")
-                ),
-                responseHeaders(
-                    headerWithName("Location").description("S3에서 제공되는 Presigned URL")
-                )
-            ));
+                .andExpect(status().isFound())
+                .andDo(document("file-generate-presigned-url",
+                        pathParameters(
+                                parameterWithName("uuid").description("Presigned URL을 생성할 문서의 UUID")
+                        ),
+                        responseHeaders(
+                                headerWithName("Location").description("S3에서 제공되는 Presigned URL")
+                        )
+                ));
     }
 }

--- a/src/test/java/doore/restdocs/docs/FileDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/FileDocsTest.java
@@ -1,0 +1,55 @@
+package doore.restdocs.docs;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import doore.restdocs.RestDocsTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class FileDocsTest extends RestDocsTest {
+
+    @Test
+    @DisplayName("[성공] 이미지 파일의 URL을 조회한다.")
+    public void 이미지_파일_URL_조회() throws Exception {
+        String uuid = "8a463aa4-b1dc-4f27-9c3f-53b94dc45e74.jpg";
+        String s3Url = "https://s3.amazonaws.com/my-bucket/images/" + uuid;
+        when(s3ImageFileService.getS3Url(uuid)).thenReturn(s3Url);
+
+        mockMvc.perform(get("/files/images/{uuid}", uuid))
+            .andExpect(status().isMovedPermanently())
+            .andDo(document("file-get-image-url",
+                pathParameters(
+                    parameterWithName("uuid").description("이미지 파일의 UUID")
+                ),
+                responseHeaders(
+                    headerWithName("Location").description("S3에서 제공되는 Public URL")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("[성공] 문서 파일의 Presigned URL을 생성한다.")
+    public void 문서_파일_Presigned_URL_생성() throws Exception {
+        String uuid = "8a463aa4-b1dc-4f27-9c3f-53b94dc45e74.pdf";
+        String presignedUrl = "https://s3.amazonaws.com/my-bucket/documents/" + uuid + "?signature=123";
+        when(s3DocumentFileService.generatePresignedUrl(uuid)).thenReturn(presignedUrl);
+
+        mockMvc.perform(get("/files/documents/{uuid}", uuid))
+            .andExpect(status().isFound())
+            .andDo(document("file-generate-presigned-url",
+                pathParameters(
+                    parameterWithName("uuid").description("Presigned URL을 생성할 문서의 UUID")
+                ),
+                responseHeaders(
+                    headerWithName("Location").description("S3에서 제공되는 Presigned URL")
+                )
+            ));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close: #253 #257

## 📝 작업 내용

> * 학습자료 파일명 저장 오류 수정
> * 학습자료 파일 URL 접근 시 다운로드 되도록 수정

## 💬 리뷰 요구사항

> * 기존에 파일명을 DB에 저장하고 있었지만 잘못된 메소드(getName)로 모든 파일이 "files"로 저장되고 프론트에 보내주고 있어 해당 값을 사용하지 않고 파일 UUID 값을 노출하고 있었습니다. 메소드를 파일 이름을 정상적으로 가져오도록 수정(getOriginalFilename)하였습니다.
> * 원본 파일명 적용 및 다운로드 설정을 위하여 S3 Presigned Url를 적용하였습니다. 이미지 파일은 브라우저에서 바로 불러와야 하기 때문에 기존처럼 Object URL을 사용하며, 이외 문서는 Presigned URL를 통해 원본 파일명 및 다운로드 옵션 지정한 링크를 제공합니다. 또한 기존에는 프론트에서 s3 baseUrl을 가지고 있었는데 백엔드에서 리다이렉트하여 접근하도록 수정하였습니다. (신규 API 추가: domain/files/{폴더명}/{UUID})