### PR TITLE
Feature/#260 학습자료 공개범위를 수정한다

### DIFF
--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -1,16 +1,19 @@
 package doore.document.application;
 
 import static doore.document.domain.DocumentGroupType.STUDY;
+import static doore.document.domain.DocumentGroupType.TEAM;
 import static doore.document.exception.DocumentExceptionType.NOT_FOUND_DOCUMENT;
 
 import doore.document.application.dto.response.DocumentResponse;
 import doore.document.application.dto.response.FileResponse;
 import doore.document.domain.Document;
+import doore.document.domain.DocumentAccessType;
 import doore.document.domain.DocumentGroupType;
 import doore.document.domain.repository.DocumentRepository;
 import doore.document.exception.DocumentException;
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
+import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.study.application.convenience.StudyConvenience;
 import doore.study.domain.Study;
 import java.util.List;
@@ -29,6 +32,7 @@ public class DocumentQueryService {
 
     private final MemberValidateAccessPermission memberValidateAccessPermission;
     private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
+    private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
 
     private final StudyConvenience studyConvenience;
 
@@ -40,12 +44,15 @@ public class DocumentQueryService {
     }
 
     public DocumentResponse getDocument(final Long documentId, final Long memberId) {
+        memberValidateAccessPermission.validateExistMember(memberId);
         final Document document = documentRepository.findById(documentId)
                 .orElseThrow(() -> new DocumentException(NOT_FOUND_DOCUMENT));
         final DocumentGroupType documentGroupType = document.getGroupType();
         final Study study = studyConvenience.findByDocumentId(documentId);
         if (documentGroupType == STUDY) {
             studyRoleValidateAccessPermission.validateExistParticipant(study.getId(), memberId);
+        } else if (documentGroupType == TEAM && document.getAccessType() == DocumentAccessType.TEAM) {
+            teamRoleValidateAccessPermission.validateExistMemberTeam(study.getTeamId(), memberId);
         }
         return toDocumentResponse(document);
     }

--- a/src/test/java/doore/document/application/DocumentQueryServiceTest.java
+++ b/src/test/java/doore/document/application/DocumentQueryServiceTest.java
@@ -1,27 +1,35 @@
 package doore.document.application;
 
+import static doore.document.domain.DocumentAccessType.ALL;
+import static doore.document.domain.DocumentGroupType.STUDY;
 import static doore.document.domain.DocumentGroupType.TEAM;
 import static doore.document.domain.DocumentType.URL;
 import static doore.member.MemberFixture.미나;
+import static doore.member.MemberFixture.아마;
 import static doore.member.MemberFixture.아마란스;
-import static doore.member.MemberFixture.짱구;
 import static doore.member.domain.StudyRoleType.ROLE_스터디원;
+import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.team.TeamFixture.team;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import doore.document.DocumentFixture;
 import doore.document.application.dto.response.DocumentResponse;
 import doore.document.domain.Document;
-import doore.document.domain.DocumentGroupType;
+import doore.document.domain.DocumentAccessType;
 import doore.document.domain.repository.DocumentRepository;
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
+import doore.member.domain.TeamRole;
+import doore.member.domain.TeamRoleType;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.StudyRoleRepository;
+import doore.member.domain.repository.TeamRoleRepository;
+import doore.member.exception.MemberException;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
 import doore.team.domain.Team;
@@ -50,88 +58,149 @@ public class DocumentQueryServiceTest extends IntegrationTest {
     private StudyRoleRepository studyRoleRepository;
     @Autowired
     private TeamRepository teamRepository;
+    @Autowired
+    private TeamRoleRepository teamRoleRepository;
 
     private Study study;
-    private Document document;
-    private Document anotherDocument;
-    private Member member;
-    private Member anotherMember;
-    private Member notMember;
+    private Document studyDocument; // 스터디 학습자료
+    private Document allOpenTeamDocument; // 전체 공개 팀 학습자료
+    private Document teamOpenTeamDocument; // 팀 공개 팀 학습자료
+    private Member participant;  // 회원 + 팀원 + 스터디원
+    private Member notMemberTeamNotParticipantMember; // 회원
+    private Member notParticipantMember; // 회원 + 팀원
     private StudyRole studyRole;
+    private TeamRole teamRole;
     private Team team;
 
     @BeforeEach
     void setUp() {
         team = teamRepository.save(team());
         study = studyRepository.save(algorithmStudy());
-        member = memberRepository.save(아마란스());
-        anotherMember = memberRepository.save(미나());
-        notMember = 짱구();
+        participant = memberRepository.save(아마란스());
+        notMemberTeamNotParticipantMember = memberRepository.save(미나());
+        notParticipantMember = memberRepository.save(아마());
+        teamRole = teamRoleRepository.save(TeamRole.builder()
+                .teamRoleType(TeamRoleType.ROLE_팀원)
+                .memberId(notParticipantMember.getId())
+                .teamId(study.getTeamId())
+                .build());
         studyRole = studyRoleRepository.save(StudyRole.builder()
                 .studyRoleType(ROLE_스터디원)
                 .studyId(study.getId())
-                .memberId(member.getId())
+                .memberId(participant.getId())
                 .build());
-        document = new DocumentFixture()
-                .groupType(DocumentGroupType.STUDY)
+        studyDocument = new DocumentFixture()
+                .groupType(STUDY)
                 .groupId(study.getId())
                 .type(URL)
-                .uploaderId(member.getId())
+                .uploaderId(participant.getId())
                 .buildDocument();
-        anotherDocument = new DocumentFixture()
+        allOpenTeamDocument = new DocumentFixture()
                 .groupType(TEAM)
                 .groupId(team.getId())
                 .type(URL)
-                .uploaderId(member.getId())
+                .accessType(ALL)
+                .uploaderId(participant.getId())
+                .buildDocument();
+        teamOpenTeamDocument = new DocumentFixture()
+                .groupType(TEAM)
+                .groupId(team.getId())
+                .type(URL)
+                .accessType(DocumentAccessType.TEAM)
+                .uploaderId(participant.getId())
                 .buildDocument();
     }
 
     @Test
     @DisplayName("[성공] 비회원이_정상적으로 팀 학습자료 목록을 조회할 수 있다")
-    public void getAllDocumentList_비회원이_정상적으로_팀_학습자료_목록을_조회할_수_있다_성공() {
+    public void getAllDocument_비회원이_정상적으로_팀_학습자료_목록을_조회할_수_있다_성공() {
         //given&when
         final Page<DocumentResponse> responses =
                 documentQueryService.getAllDocument(TEAM, team.getId(), PageRequest.of(0, 4));
-        final String uploaderName = memberRepository.findById(document.getUploaderId()).orElseThrow().getName();
+        final String uploaderName = memberRepository.findById(allOpenTeamDocument.getUploaderId()).orElseThrow()
+                .getName();
 
         //then
         assertAll(
                 () -> assertThat(responses.getTotalElements()).isNotZero(),
-                () -> assertEquals(responses.getContent().get(0).title(), anotherDocument.getName()),
-                () -> assertEquals(responses.getContent().get(0).description(), anotherDocument.getDescription()),
-                () -> assertEquals(responses.getContent().get(0).date(), anotherDocument.getCreatedAt().toLocalDate()),
+                () -> assertEquals(responses.getContent().get(0).title(), allOpenTeamDocument.getName()),
+                () -> assertEquals(responses.getContent().get(0).description(), allOpenTeamDocument.getDescription()),
+                () -> assertEquals(responses.getContent().get(0).date(),
+                        allOpenTeamDocument.getCreatedAt().toLocalDate()),
                 () -> assertEquals(responses.getContent().get(0).uploaderName(), uploaderName)
         );
     }
 
     @Test
-    @DisplayName("[성공] 정상적으로 팀 학습자료 상세를 조회할 수 있다.")
-    public void getDocument_정상적으로_팀_학습자료_상세를_조회할_수_있다_성공() {
+    @DisplayName("[성공] 회원은 정상적으로 전체공개 팀 학습자료 상세를 조회할 수 있다.")
+    public void getDocument_회원은_정상적으로_전체공개_팀_학습자료_상세를_조회할_수_있다_성공() {
         //given&when
-        final DocumentResponse response = documentQueryService.getDocument(anotherDocument.getId(),
-                notMember.getId());
+        final DocumentResponse response = documentQueryService.getDocument(allOpenTeamDocument.getId(),
+                notMemberTeamNotParticipantMember.getId());
 
         //then
         assertAll(
-                () -> assertEquals(response.title(), anotherDocument.getName()),
-                () -> assertEquals(response.description(), anotherDocument.getDescription()),
-                () -> assertEquals(response.date(), anotherDocument.getCreatedAt().toLocalDate()),
-                () -> assertEquals(response.accessType(), anotherDocument.getAccessType())
+                () -> assertEquals(response.title(), allOpenTeamDocument.getName()),
+                () -> assertEquals(response.description(), allOpenTeamDocument.getDescription()),
+                () -> assertEquals(response.date(), allOpenTeamDocument.getCreatedAt().toLocalDate()),
+                () -> assertEquals(response.accessType(), allOpenTeamDocument.getAccessType())
         );
     }
 
     @Test
-    @DisplayName("[성공] 정상적으로 스터디 학습자료 상세를 조회할 수 있다")
-    public void getDocument_정상적으로_스터디_학습자료_상세를_조회할_수_있다_성공() {
+    @DisplayName("[성공] 팀원은 정상적으로 팀공개 팀 학습자료 상세를 조회할 수 있다.")
+    public void getDocument_팀원은_정상적으로_팀공개_팀_학습자료_상세를_조회할_수_있다_성공() {
         //given&when
-        final DocumentResponse response = documentQueryService.getDocument(document.getId(), member.getId());
+        final DocumentResponse response = documentQueryService.getDocument(teamOpenTeamDocument.getId(),
+                notParticipantMember.getId());
 
         //then
         assertAll(
-                () -> assertEquals(response.title(), document.getName()),
-                () -> assertEquals(response.description(), document.getDescription()),
-                () -> assertEquals(response.date(), document.getCreatedAt().toLocalDate()),
-                () -> assertEquals(response.accessType(), document.getAccessType())
+                () -> assertEquals(response.title(), teamOpenTeamDocument.getName()),
+                () -> assertEquals(response.description(), teamOpenTeamDocument.getDescription()),
+                () -> assertEquals(response.date(), teamOpenTeamDocument.getCreatedAt().toLocalDate()),
+                () -> assertEquals(response.accessType(), teamOpenTeamDocument.getAccessType())
         );
+    }
+
+    @Test
+    @DisplayName("[실패] 회원은 팀공개 팀 학습자료 상세 조회를 할 수 없다.")
+    public void getDocument_회원은_팀공개_팀_학습자료_상세_조회를_할_수_없다_실패() {
+        assertThatThrownBy(
+                () -> documentQueryService.getDocument(teamOpenTeamDocument.getId(),
+                        notMemberTeamNotParticipantMember.getId()))
+                .isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 스터디원은 정상적으로 스터디 학습자료 상세를 조회할 수 있다")
+    public void getDocument_스터디원은_정상적으로_스터디_학습자료_상세를_조회할_수_있다_성공() {
+        //given&when
+        final DocumentResponse response = documentQueryService.getDocument(studyDocument.getId(), participant.getId());
+
+        //then
+        assertAll(
+                () -> assertEquals(response.title(), studyDocument.getName()),
+                () -> assertEquals(response.description(), studyDocument.getDescription()),
+                () -> assertEquals(response.date(), studyDocument.getCreatedAt().toLocalDate()),
+                () -> assertEquals(response.accessType(), studyDocument.getAccessType())
+        );
+    }
+
+    @Test
+    @DisplayName("[실패] 회원은 스터디 학습자료 상세 조회를 할 수 없다.")
+    public void getDocument_회원은_스터디_학습자료_상세_조회를_할_수_없다_실패() {
+        assertThatThrownBy(
+                () -> documentQueryService.getDocument(studyDocument.getId(),
+                        notMemberTeamNotParticipantMember.getId()))
+                .isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 팀원은 팀 학습자료 상세 조회를 할 수 없다.")
+    public void getDocument_회원은_팀_학습자료_상세_조회를_할_수_없다_실패() {
+        assertThatThrownBy(
+                () -> documentQueryService.getDocument(studyDocument.getId(), notParticipantMember.getId()))
+                .isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #260 

## 📝 작업 내용

- 학습자료 공개 범위를 지난 회의 바탕 + 스터디 파트 프론트 담당 도리님과 의논 끝에 정리했습니다!
    - 학습자료의 종류는 3가지가 있습니다. 또한 비회원, 회원(팀원X, 스터디원X), 팀원(스터디원X), 스터디원으로 정의하겠습니다.
        - 팀 학습자료 + 전체 공개 => 회원 이상부터 공개
        - 팀 학습자료 + 팀 공개 => 팀원 이상부터 공개
        - 스터디 학습자료 => 스터디원에게만 공개
    - 스터디 학습자료도 전체공개와 팀공개가 있었으나, 그렇게 되면 팀 학습자료와 스터디 학습자료가 생성되는 위치만 다를 뿐 접근이 동일하기 때문에 스터디 학습자료의 목적이 사라진다고 판단하여 스터디에서 만들어진 학습자료는 모두 스터디원에게만 공개하기로 하였습니다. 그에 따른 스터디 학습자료의 request 값은 프론트에서 All 또는 Team 중 하나 고정해서 보내준다고 합니다!

## 💬 리뷰 요구사항

- 음... 테스트 코드..?
