### PR TITLE
Feature/#263 탈퇴한 스터디가 사이드바에 남아있는 문제 해결

### DIFF
--- a/src/main/java/doore/study/domain/repository/StudyRepository.java
+++ b/src/main/java/doore/study/domain/repository/StudyRepository.java
@@ -18,10 +18,11 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
     List<Study> findAllByTeamId(Long teamId);
 
     Page<Study> findAllByTeamId(Long teamId, Pageable pageable);
+
     @Query("select s from Study s join Document d on d.groupId = s.id where d.id = :documentId")
     Study findByDocumentId(Long documentId);
 
-    @Query("SELECT s FROM Study s JOIN Participant p ON p.studyId = s.id " +
-            "WHERE p.member.id = :memberId AND s.teamId = :teamId")
+    @Query("SELECT s FROM Study s JOIN Participant p ON s.id = p.studyId " + "WHERE s.teamId = :teamId "
+            + "  AND s.isDeleted = false " + "  AND p.member.id = :memberId " + "  AND p.isDeleted = false")
     List<Study> findAllByTeamIdAndMemberId(Long teamId, Long memberId);
 }

--- a/src/main/java/doore/team/application/TeamQueryService.java
+++ b/src/main/java/doore/team/application/TeamQueryService.java
@@ -55,7 +55,8 @@ public class TeamQueryService {
 
         return myTeams.stream()
                 .map(team -> {
-                    List<StudyNameResponse> studyNameResponses = studyRepository.findAllByTeamId(team.getId()).stream()
+                    List<StudyNameResponse> studyNameResponses = studyRepository.findAllByTeamIdAndMemberId(
+                                    team.getId(), memberId).stream()
                             .map(StudyNameResponse::from)
                             .toList();
                     return MyTeamsAndStudiesResponse.of(team, studyNameResponses);

--- a/src/test/java/doore/member/application/MemberQueryServiceTest.java
+++ b/src/test/java/doore/member/application/MemberQueryServiceTest.java
@@ -113,4 +113,16 @@ public class MemberQueryServiceTest extends IntegrationTest {
         assertThat(actual.myTeamsAndStudies().size()).isEqualTo(1);
         assertThat(actual.myTeamsAndStudies().get(0).teamStudies().size()).isEqualTo(1);
     }
+
+    @Test
+    @DisplayName("[성공] 삭제된 스터디는 나의 팀 내역에 포함되지 않는다.")
+    void getSideBarInfo_삭제된_스터디는_나의_팀_내역에_포함되지_않는다_성공() {
+        participantRepository.deleteByStudyIdAndMemberId(study.getId(), member.getId());
+
+        final MemberAndMyTeamsAndStudiesResponse actual = memberQueryService.getSideBarInfo(member.getId(),
+                member.getId());
+
+        assertThat(actual.myTeamsAndStudies().size()).isEqualTo(2);
+        assertThat(actual.myTeamsAndStudies().get(0).teamStudies().size()).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #263 

## 📝 작업 내용

- 스터디 탈퇴 시 사이드바에서 사라지지 않는 문제를 해결하였습니다.

## 💬 리뷰 요구사항

- 회의 때 고쳤던 기억이 난다고 했었는데 팀이 사라지지 않는 문제를 해결했던 거였더라고요ㅠㅠ
그 당시 팀을 탈퇴하면 자동으로 스터디(팀이 조회되지 않아서)는 안뜨니까^^ 이러고 넘어갔는데, 스터디만 삭제하는 경우를 생각하지 않았던 저의 실수였답니다...
