### PR TITLE
Feature/#273 팀장이 스터디 학습자료 생성이 가능한 문제 해결

### DIFF
--- a/src/main/java/doore/document/application/DocumentCommandService.java
+++ b/src/main/java/doore/document/application/DocumentCommandService.java
@@ -18,6 +18,7 @@ import doore.file.application.S3DocumentFileService;
 import doore.file.application.S3ImageFileService;
 import doore.garden.application.convenience.GardenConvenience;
 import doore.member.application.convenience.MemberValidateAccessPermission;
+import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.study.application.convenience.StudyValidateAccessPermission;
 import doore.team.application.convenience.TeamValidateAccessPermission;
 import java.util.ArrayList;
@@ -36,10 +37,11 @@ public class DocumentCommandService {
 
     private final S3ImageFileService s3ImageFileService;
     private final S3DocumentFileService s3DocumentFileService;
-    private final GardenConvenience gardenCommandService;
 
+    private final GardenConvenience gardenCommandService;
     private final TeamValidateAccessPermission teamValidateAccessPermission;
     private final StudyValidateAccessPermission studyValidateAccessPermission;
+    private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
     private final MemberValidateAccessPermission memberValidateAccessPermission;
     private final DocumentValidateAccessPermission documentValidateAccessPermission;
 
@@ -47,6 +49,9 @@ public class DocumentCommandService {
                                final DocumentGroupType groupType, final Long groupId, final Long memberId) {
         memberValidateAccessPermission.validateExistMember(memberId);
         validateExistGroup(groupType, groupId);
+        if (groupType == STUDY) {
+            studyRoleValidateAccessPermission.validateExistParticipant(groupId, memberId);
+        }
         documentValidateAccessPermission.validateDocumentType(request.type(), request.url(), multipartFiles);
         final Document document = Document.from(request, groupType, groupId);
 

--- a/src/main/java/doore/document/application/DocumentCommandService.java
+++ b/src/main/java/doore/document/application/DocumentCommandService.java
@@ -21,7 +21,6 @@ import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.study.application.convenience.StudyValidateAccessPermission;
 import doore.team.application.convenience.TeamValidateAccessPermission;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -53,24 +52,11 @@ public class DocumentCommandService {
             studyRoleValidateAccessPermission.validateExistParticipant(groupId, memberId);
         }
         documentValidateAccessPermission.validateDocumentType(request.type(), request.url(), multipartFiles);
+
         final Document document = Document.from(request, groupType, groupId);
-
         documentRepository.save(document);
+        processDocumentFiles(document, request.url(), multipartFiles);
 
-        if (document.getType().equals(DocumentType.URL)) {
-            final File newFile = createFile(request.url(), "", document);
-            document.updateFiles(List.of(newFile));
-        }
-        if (!document.getType().equals(DocumentType.URL)) {
-            final List<File> newFiles = new ArrayList<>();
-            for (MultipartFile file : multipartFiles) {
-                final String filename = file.getOriginalFilename();
-                final String filePath = uploadFileToS3(document.getType(), file);
-                final File newFile = createFile(filePath, filename, document);
-                newFiles.add(newFile);
-            }
-            document.updateFiles(newFiles);
-        }
         gardenCommandService.createDocumentGarden(document);
     }
 
@@ -96,6 +82,31 @@ public class DocumentCommandService {
         if (groupType.equals(STUDY)) {
             studyValidateAccessPermission.validateExistStudy(groupId);
         }
+    }
+
+    private void processDocumentFiles(final Document document, final String url,
+                                      final List<MultipartFile> multipartFiles) {
+        if (document.getType().equals(DocumentType.URL)) {
+            processUrlDocument(document, url);
+        } else {
+            processUploadedFiles(document, multipartFiles);
+        }
+    }
+
+    private void processUrlDocument(final Document document, final String url) {
+        final File newFile = createFile(url, "", document);
+        document.updateFiles(List.of(newFile));
+    }
+
+    private void processUploadedFiles(final Document document, final List<MultipartFile> multipartFiles) {
+        List<File> newFiles = multipartFiles.stream()
+                .map(file -> {
+                    final String filename = file.getOriginalFilename();
+                    final String filePath = uploadFileToS3(document.getType(), file);
+                    return createFile(filePath, filename, document);
+                })
+                .toList();
+        document.updateFiles(newFiles);
     }
 
     //todo: 파일 관련 코드 정리 필요

--- a/src/test/java/doore/document/application/DocumentCommandServiceTest.java
+++ b/src/test/java/doore/document/application/DocumentCommandServiceTest.java
@@ -6,6 +6,8 @@ import static doore.document.exception.DocumentExceptionType.NO_FILE_ATTACHED;
 import static doore.garden.domain.GardenType.DOCUMENT_UPLOAD;
 import static doore.member.MemberFixture.createMember;
 import static doore.member.MemberFixture.미나;
+import static doore.member.MemberFixture.아마란스;
+import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.study.StudyFixture.createStudy;
@@ -32,7 +34,14 @@ import doore.garden.domain.Garden;
 import doore.garden.domain.repository.GardenRepository;
 import doore.helper.IntegrationTest;
 import doore.member.domain.Member;
+import doore.member.domain.Participant;
+import doore.member.domain.StudyRole;
+import doore.member.domain.TeamRole;
+import doore.member.domain.TeamRoleType;
 import doore.member.domain.repository.MemberRepository;
+import doore.member.domain.repository.ParticipantRepository;
+import doore.member.domain.repository.StudyRoleRepository;
+import doore.member.domain.repository.TeamRoleRepository;
 import doore.member.exception.MemberException;
 import doore.study.domain.Study;
 import doore.study.domain.repository.StudyRepository;
@@ -58,6 +67,13 @@ public class DocumentCommandServiceTest extends IntegrationTest {
     @Autowired
     private MemberRepository memberRepository;
     @Autowired
+    private ParticipantRepository participantRepository;
+    @Autowired
+    private StudyRoleRepository studyRoleRepository;
+    @Autowired
+    private TeamRoleRepository teamRoleRepository;
+
+    @Autowired
     private DocumentCommandService documentCommandService;
     @Autowired
     private GardenConvenience gardenCommandService;
@@ -69,6 +85,9 @@ public class DocumentCommandServiceTest extends IntegrationTest {
     private DocumentCreateRequest documentRequest;
     private Study study;
     private Member member;
+    private Member notParticipantMember;
+    private StudyRole studyRole;
+    private TeamRole teamRole;
 
     @BeforeEach
     void setUp() {
@@ -77,6 +96,18 @@ public class DocumentCommandServiceTest extends IntegrationTest {
         study = createStudy();
         study = studyRepository.save(algorithmStudy());
         member = memberRepository.save(미나());
+        notParticipantMember = memberRepository.save(아마란스());
+        participantRepository.save(Participant.builder().member(member).studyId(study.getId()).build());
+        studyRoleRepository.save(StudyRole.builder().
+                studyId(study.getId())
+                .studyRoleType(ROLE_스터디원)
+                .memberId(member.getId())
+                .build());
+        teamRoleRepository.save(TeamRole.builder()
+                .teamId(study.getTeamId())
+                .teamRoleType(TeamRoleType.ROLE_팀장)
+                .memberId(notParticipantMember.getId())
+                .build());
     }
 
     @Nested
@@ -115,6 +146,16 @@ public class DocumentCommandServiceTest extends IntegrationTest {
                     () -> assertThat(documents.get(0).getFiles()).hasSize(1),
                     () -> assertEquals(documents.get(0).getName(), documentRequest.title())
             );
+        }
+
+        @Test
+        @DisplayName("[실패] 스터디 구성원이 아니라면 스터디 학습자료를 생성할 수 없다.")
+        void createDocument_스터디_구성원이_아니라면_스터디_학습자료를_생성할_수_없다_실패() {
+            assertThatThrownBy(() ->
+                    documentCommandService.createDocument(documentRequest, null, STUDY, study.getId(),
+                            notParticipantMember.getId()))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(UNAUTHORIZED.errorMessage());
         }
 
         @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #273 

## 📝 작업 내용

- 팀장이 스터디 학습자료 생성이 가능했던 문제를 해결하였습니다.
- 추가로 createDocument의 메서드 분리를 진행하였습니다.

## 💬 리뷰 요구사항

- documentCommandService 아래에 file 관련 todo가 적혀있던데(파일 관련 코드 정리 필요), 이 코드가 파일쪽에 있는 것이 좋을지 그대로 있는게 좋을지 고민하다가 그냥 두었습니다.. @yessjun 님 생각은 어떠신가요??