### PR TITLE
Feature/#277 마이페이지 프로필 이미지 삭제 api 개발

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -79,3 +79,14 @@ include::{snippets}/myPage-image-update/http-response.adoc[]
 
 .Path Parameters
 include::{snippets}/myPage-image-update/path-parameters.adoc[]
+
+== `DELETE`: 마이페이지 이미지 삭제
+
+.HTTP Request
+include::{snippets}/myPage-image-delete/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/myPage-image-delete/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/myPage-image-delete/path-parameters.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -57,3 +57,14 @@ include::{snippets}/get-sidebar-info/http-response.adoc[]
 
 .Response Body's Fields
 include::{snippets}/get-sidebar-info/response-body.adoc[]
+
+== `PATCH`: 마이페이지 수정
+
+.HTTP Request
+include::{snippets}/myPage-update/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/myPage-update/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/myPage-update/path-parameters.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -68,3 +68,14 @@ include::{snippets}/myPage-update/http-response.adoc[]
 
 .Path Parameters
 include::{snippets}/myPage-update/path-parameters.adoc[]
+
+== `PATCH`: 마이페이지 이미지 수정
+
+.HTTP Request
+include::{snippets}/myPage-image-update/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/myPage-image-update/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/myPage-image-update/path-parameters.adoc[]

--- a/src/main/java/doore/member/api/MemberController.java
+++ b/src/main/java/doore/member/api/MemberController.java
@@ -69,4 +69,10 @@ public class MemberController {
         memberCommandService.updateMyPageImage(memberId, file, member.getId());
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/myPage/members/{memberId}/image") // 개인
+    public ResponseEntity<Void> deleteMyPageImage(@PathVariable final Long memberId, @LoginMember final Member member) {
+        memberCommandService.deleteMyPageImage(memberId, member.getId());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/doore/member/api/MemberController.java
+++ b/src/main/java/doore/member/api/MemberController.java
@@ -47,13 +47,13 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/members/{memberId}")
+    @GetMapping("/members/{memberId}") // 개인
     public ResponseEntity<MemberAndMyTeamsAndStudiesResponse> getSideBarInfo(@PathVariable final Long memberId,
                                                                              @LoginMember final Member member) {
         return ResponseEntity.ok(memberQueryService.getSideBarInfo(memberId, member.getId()));
     }
 
-    @PatchMapping("/myPage/members/{memberId}")
+    @PatchMapping("/myPage/members/{memberId}") // 개인
     public ResponseEntity<Void> updateMyPage(@Valid @RequestBody final MyPageUpdateRequest request,
                                              @PathVariable final Long memberId, @LoginMember final Member member) {
         memberCommandService.updateMyPage(request, memberId, member.getId());

--- a/src/main/java/doore/member/api/MemberController.java
+++ b/src/main/java/doore/member/api/MemberController.java
@@ -55,24 +55,23 @@ public class MemberController {
         return ResponseEntity.ok(memberQueryService.getSideBarInfo(memberId, member.getId()));
     }
 
-    @PatchMapping("/myPage/members/{memberId}") // 개인
+    @PatchMapping("/members/me") // 개인
     public ResponseEntity<Void> updateMyPage(@Valid @RequestBody final MyPageUpdateRequest request,
-                                             @PathVariable final Long memberId, @LoginMember final Member member) {
-        memberCommandService.updateMyPage(request, memberId, member.getId());
+                                             @LoginMember final Member member) {
+        memberCommandService.updateMyPage(request, member.getId());
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/myPage/members/{memberId}/image") // 개인
-    public ResponseEntity<Void> updateMyPageImage(@PathVariable final Long memberId,
-                                                  @RequestPart(required = false) final MultipartFile file,
+    @PatchMapping("/members/me/image") // 개인
+    public ResponseEntity<Void> updateMyPageImage(@RequestPart(required = false) final MultipartFile file,
                                                   @LoginMember final Member member) {
-        memberCommandService.updateMyPageImage(memberId, file, member.getId());
+        memberCommandService.updateMyPageImage(file, member.getId());
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/myPage/members/{memberId}/image") // 개인
-    public ResponseEntity<Void> deleteMyPageImage(@PathVariable final Long memberId, @LoginMember final Member member) {
-        memberCommandService.deleteMyPageImage(memberId, member.getId());
+    @DeleteMapping("/members/me/image") // 개인
+    public ResponseEntity<Void> deleteMyPageImage(@LoginMember final Member member) {
+        memberCommandService.deleteMyPageImage(member.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/doore/member/api/MemberController.java
+++ b/src/main/java/doore/member/api/MemberController.java
@@ -3,8 +3,10 @@ package doore.member.api;
 import doore.member.application.MemberCommandService;
 import doore.member.application.MemberQueryService;
 import doore.member.application.dto.response.MemberAndMyTeamsAndStudiesResponse;
+import doore.member.application.dto.response.MyPageUpdateRequest;
 import doore.member.domain.Member;
 import doore.resolver.LoginMember;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -46,7 +49,15 @@ public class MemberController {
 
     @GetMapping("/members/{memberId}")
     public ResponseEntity<MemberAndMyTeamsAndStudiesResponse> getSideBarInfo(@PathVariable final Long memberId,
-                                                                                   @LoginMember final Member member) {
+                                                                             @LoginMember final Member member) {
         return ResponseEntity.ok(memberQueryService.getSideBarInfo(memberId, member.getId()));
     }
+
+    @PatchMapping("/myPage/members/{memberId}")
+    public ResponseEntity<Void> updateMyPage(@Valid @RequestBody final MyPageUpdateRequest request,
+                                             @PathVariable final Long memberId, @LoginMember final Member member) {
+        memberCommandService.updateMyPage(request, memberId, member.getId());
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/doore/member/api/MemberController.java
+++ b/src/main/java/doore/member/api/MemberController.java
@@ -15,7 +15,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Validated
 @RestController
@@ -60,4 +62,11 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
+    @PatchMapping("/myPage/members/{memberId}/image") // 개인
+    public ResponseEntity<Void> updateMyPageImage(@PathVariable final Long memberId,
+                                                  @RequestPart(required = false) final MultipartFile file,
+                                                  @LoginMember final Member member) {
+        memberCommandService.updateMyPageImage(memberId, file, member.getId());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/doore/member/api/MemberController.java
+++ b/src/main/java/doore/member/api/MemberController.java
@@ -3,7 +3,7 @@ package doore.member.api;
 import doore.member.application.MemberCommandService;
 import doore.member.application.MemberQueryService;
 import doore.member.application.dto.response.MemberAndMyTeamsAndStudiesResponse;
-import doore.member.application.dto.response.MyPageUpdateRequest;
+import doore.member.application.dto.request.MyPageUpdateRequest;
 import doore.member.domain.Member;
 import doore.resolver.LoginMember;
 import jakarta.validation.Valid;

--- a/src/main/java/doore/member/application/MemberCommandService.java
+++ b/src/main/java/doore/member/application/MemberCommandService.java
@@ -78,24 +78,21 @@ public class MemberCommandService {
         memberRepository.delete(member);
     }
 
-    public void updateMyPage(final MyPageUpdateRequest request, final Long memberId, final Long tokenMemberId) {
-        final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
-        memberConvenience.checkSameMemberIdAndTokenMemberId(memberId, tokenMemberId);
+    public void updateMyPage(final MyPageUpdateRequest request, final Long tokenMemberId) {
+        final Member member = memberValidateAccessPermission.getValidateExistMember(tokenMemberId);
         member.updateMyPage(request.name());
     }
 
-    public void updateMyPageImage(final Long memberId, final MultipartFile file, final Long tokenMemberId) {
-        final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
-        memberConvenience.checkSameMemberIdAndTokenMemberId(memberId, tokenMemberId);
+    public void updateMyPageImage(final MultipartFile file, final Long tokenMemberId) {
+        final Member member = memberValidateAccessPermission.getValidateExistMember(tokenMemberId);
         checkHasImageAndDelete(member);
 
         final String newImageUrl = s3ImageFileService.upload(file);
         member.updateImageUrl(newImageUrl);
     }
 
-    public void deleteMyPageImage(final Long memberId, final Long tokenMemberId) {
-        final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
-        memberConvenience.checkSameMemberIdAndTokenMemberId(memberId, tokenMemberId);
+    public void deleteMyPageImage(final Long tokenMemberId) {
+        final Member member = memberValidateAccessPermission.getValidateExistMember(tokenMemberId);
         checkHasImageAndDelete(member);
 
         member.updateImageUrl(DEFAULT_IMAGE_URL);

--- a/src/main/java/doore/member/application/MemberCommandService.java
+++ b/src/main/java/doore/member/application/MemberCommandService.java
@@ -6,7 +6,7 @@ import doore.member.application.convenience.MemberConvenience;
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.application.convenience.TeamRoleValidateAccessPermission;
-import doore.member.application.dto.response.MyPageUpdateRequest;
+import doore.member.application.dto.request.MyPageUpdateRequest;
 import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
 import doore.member.domain.TeamRole;

--- a/src/main/java/doore/member/application/MemberCommandService.java
+++ b/src/main/java/doore/member/application/MemberCommandService.java
@@ -1,9 +1,11 @@
 package doore.member.application;
 
 import doore.login.application.dto.response.GoogleAccountProfileResponse;
+import doore.member.application.convenience.MemberConvenience;
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.application.convenience.TeamRoleValidateAccessPermission;
+import doore.member.application.dto.response.MyPageUpdateRequest;
 import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
 import doore.member.domain.TeamRole;
@@ -20,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCommandService {
 
     private final MemberRepository memberRepository;
+
+    private final MemberConvenience memberConvenience;
 
     private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
     private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
@@ -67,4 +71,11 @@ public class MemberCommandService {
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         memberRepository.delete(member);
     }
+
+    public void updateMyPage(final MyPageUpdateRequest request, final Long memberId, final Long tokenMemberId) {
+        final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
+        memberConvenience.checkSameMemberIdAndTokenMemberId(memberId, tokenMemberId);
+        member.updateMyPage(request.name());
+    }
+
 }

--- a/src/main/java/doore/member/application/MemberCommandService.java
+++ b/src/main/java/doore/member/application/MemberCommandService.java
@@ -35,6 +35,8 @@ public class MemberCommandService {
     private final StudyValidateAccessPermission studyValidateAccessPermission;
     private final MemberValidateAccessPermission memberValidateAccessPermission;
 
+    private static final String DEFAULT_IMAGE_URL = "TEMP_URL";
+
     // TODO: 1/23/24 추후 소셜 로그인 플랫폼이 늘어나는 경우의 확장성 관련해서 논의
     public Member findOrCreateMemberBy(final GoogleAccountProfileResponse profile) {
         return memberRepository.findByGoogleId(profile.id())
@@ -89,6 +91,14 @@ public class MemberCommandService {
 
         final String newImageUrl = s3ImageFileService.upload(file);
         member.updateImageUrl(newImageUrl);
+    }
+
+    public void deleteMyPageImage(final Long memberId, final Long tokenMemberId) {
+        final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
+        memberConvenience.checkSameMemberIdAndTokenMemberId(memberId, tokenMemberId);
+        checkHasImageAndDelete(member);
+
+        member.updateImageUrl(DEFAULT_IMAGE_URL);
     }
 
     private void checkHasImageAndDelete(final Member member) {

--- a/src/main/java/doore/member/application/MemberCommandService.java
+++ b/src/main/java/doore/member/application/MemberCommandService.java
@@ -1,5 +1,6 @@
 package doore.member.application;
 
+import doore.file.application.S3ImageFileService;
 import doore.login.application.dto.response.GoogleAccountProfileResponse;
 import doore.member.application.convenience.MemberConvenience;
 import doore.member.application.convenience.MemberValidateAccessPermission;
@@ -15,6 +16,7 @@ import doore.team.application.convenience.TeamValidateAccessPermission;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -24,6 +26,8 @@ public class MemberCommandService {
     private final MemberRepository memberRepository;
 
     private final MemberConvenience memberConvenience;
+
+    private final S3ImageFileService s3ImageFileService;
 
     private final TeamRoleValidateAccessPermission teamRoleValidateAccessPermission;
     private final StudyRoleValidateAccessPermission studyRoleValidateAccessPermission;
@@ -76,6 +80,21 @@ public class MemberCommandService {
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         memberConvenience.checkSameMemberIdAndTokenMemberId(memberId, tokenMemberId);
         member.updateMyPage(request.name());
+    }
+
+    public void updateMyPageImage(final Long memberId, final MultipartFile file, final Long tokenMemberId) {
+        final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
+        memberConvenience.checkSameMemberIdAndTokenMemberId(memberId, tokenMemberId);
+        checkHasImageAndDelete(member);
+
+        final String newImageUrl = s3ImageFileService.upload(file);
+        member.updateImageUrl(newImageUrl);
+    }
+
+    private void checkHasImageAndDelete(final Member member) {
+        if (member.hasImage()) {
+            s3ImageFileService.deleteFile(member.getImageUrl());
+        }
     }
 
 }

--- a/src/main/java/doore/member/application/dto/request/MyPageUpdateRequest.java
+++ b/src/main/java/doore/member/application/dto/request/MyPageUpdateRequest.java
@@ -1,9 +1,9 @@
 package doore.member.application.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record MyPageUpdateRequest(
-        @NotNull(message = "이름을 입력해주세요.")
+        @NotBlank(message = "이름을 입력해주세요.")
         String name
 ) {
 }

--- a/src/main/java/doore/member/application/dto/request/MyPageUpdateRequest.java
+++ b/src/main/java/doore/member/application/dto/request/MyPageUpdateRequest.java
@@ -1,4 +1,4 @@
-package doore.member.application.dto.response;
+package doore.member.application.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/doore/member/application/dto/response/MyPageUpdateRequest.java
+++ b/src/main/java/doore/member/application/dto/response/MyPageUpdateRequest.java
@@ -1,0 +1,9 @@
+package doore.member.application.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MyPageUpdateRequest(
+        @NotNull(message = "이름을 입력해주세요.")
+        String name
+) {
+}

--- a/src/main/java/doore/member/domain/Member.java
+++ b/src/main/java/doore/member/domain/Member.java
@@ -51,4 +51,12 @@ public class Member extends BaseEntity {
     public void updateMyPage(String name) {
         this.name = name;
     }
+
+    public boolean hasImage() {
+        return !imageUrl.equals("");
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/doore/member/domain/Member.java
+++ b/src/main/java/doore/member/domain/Member.java
@@ -47,4 +47,8 @@ public class Member extends BaseEntity {
         this.imageUrl = imageUrl;
         this.isDeleted = false;
     }
+
+    public void updateMyPage(String name) {
+        this.name = name;
+    }
 }

--- a/src/test/java/doore/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberCommandServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.multipart.MultipartFile;
 
 class MemberCommandServiceTest extends IntegrationTest {
     @Autowired
@@ -252,6 +253,17 @@ class MemberCommandServiceTest extends IntegrationTest {
 
         assertThatThrownBy(() -> {
             memberCommandService.updateMyPage(request, member.getId(), otherMember.getId());
+        }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 본인이 아니라면 마이페이지 이미지를 수정할 수 없다.")
+    void updateMyPageImage_본인이_아니라면_마이페이지_이미지를_수정할_수_없다_실패() {
+        final Member otherMember = memberRepository.save(미나());
+        final MultipartFile file = getMockImageFile();
+
+        assertThatThrownBy(() -> {
+            memberCommandService.updateMyPageImage(member.getId(), file, otherMember.getId());
         }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
     }
 }

--- a/src/test/java/doore/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberCommandServiceTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.multipart.MultipartFile;
 
 class MemberCommandServiceTest extends IntegrationTest {
     @Autowired
@@ -239,41 +238,10 @@ class MemberCommandServiceTest extends IntegrationTest {
         final Member beforeMemberInfo = memberRepository.findById(member.getId()).orElseThrow();
         assertThat(beforeMemberInfo.getName()).isEqualTo("아마란스");
 
-        memberCommandService.updateMyPage(request, member.getId(), member.getId());
+        memberCommandService.updateMyPage(request, member.getId());
         final Member afterMemberInfo = memberRepository.findById(member.getId()).orElseThrow();
 
         assertThat(afterMemberInfo.getName()).isEqualTo(request.name());
     }
 
-    @Test
-    @DisplayName("[실패] 본인이 아니라면 마이페이지 정보를 수정할 수 없다.")
-    void updateMyPage_본인이_아니라면_마이페이지_정보를_수정할_수_없다_실패() {
-        final MyPageUpdateRequest request = new MyPageUpdateRequest("수정된 이름");
-        final Member otherMember = memberRepository.save(미나());
-
-        assertThatThrownBy(() -> {
-            memberCommandService.updateMyPage(request, member.getId(), otherMember.getId());
-        }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
-    }
-
-    @Test
-    @DisplayName("[실패] 본인이 아니라면 마이페이지 이미지를 수정할 수 없다.")
-    void updateMyPageImage_본인이_아니라면_마이페이지_이미지를_수정할_수_없다_실패() {
-        final Member otherMember = memberRepository.save(미나());
-        final MultipartFile file = getMockImageFile();
-
-        assertThatThrownBy(() -> {
-            memberCommandService.updateMyPageImage(member.getId(), file, otherMember.getId());
-        }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
-    }
-
-    @Test
-    @DisplayName("[실패] 본인이 아니라면 마이페이지 이미지를 삭제할 수 없다.")
-    void deleteMyPageImage_본인이_아니라면_마이페이지_이미지를_삭제할_수_없다_실패() {
-        final Member otherMember = memberRepository.save(미나());
-
-        assertThatThrownBy(() -> {
-            memberCommandService.deleteMyPageImage(member.getId(), otherMember.getId());
-        }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
-    }
 }

--- a/src/test/java/doore/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberCommandServiceTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import doore.helper.IntegrationTest;
 import doore.login.application.dto.response.GoogleAccountProfileResponse;
-import doore.member.application.dto.response.MyPageUpdateRequest;
+import doore.member.application.dto.request.MyPageUpdateRequest;
 import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
 import doore.member.domain.TeamRole;

--- a/src/test/java/doore/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberCommandServiceTest.java
@@ -266,4 +266,14 @@ class MemberCommandServiceTest extends IntegrationTest {
             memberCommandService.updateMyPageImage(member.getId(), file, otherMember.getId());
         }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
     }
+
+    @Test
+    @DisplayName("[실패] 본인이 아니라면 마이페이지 이미지를 삭제할 수 없다.")
+    void deleteMyPageImage_본인이_아니라면_마이페이지_이미지를_삭제할_수_없다_실패() {
+        final Member otherMember = memberRepository.save(미나());
+
+        assertThatThrownBy(() -> {
+            memberCommandService.deleteMyPageImage(member.getId(), otherMember.getId());
+        }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
+    }
 }

--- a/src/test/java/doore/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberCommandServiceTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import doore.helper.IntegrationTest;
 import doore.login.application.dto.response.GoogleAccountProfileResponse;
+import doore.member.application.dto.response.MyPageUpdateRequest;
 import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
 import doore.member.domain.TeamRole;
@@ -228,5 +229,29 @@ class MemberCommandServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> {
             memberCommandService.transferStudyLeader(study.getId(), member.getId(), notStudyLeaderMember.getId());
         });
+    }
+
+    @Test
+    @DisplayName("[성공] 정상적으로 마이페이지 정보를 수정할 수 있다.")
+    void updateMyPage_정상적으로_마이페이지_정보를_수정할_수_있다_성공() {
+        final MyPageUpdateRequest request = new MyPageUpdateRequest("수정된 이름");
+        final Member beforeMemberInfo = memberRepository.findById(member.getId()).orElseThrow();
+        assertThat(beforeMemberInfo.getName()).isEqualTo("아마란스");
+
+        memberCommandService.updateMyPage(request, member.getId(), member.getId());
+        final Member afterMemberInfo = memberRepository.findById(member.getId()).orElseThrow();
+
+        assertThat(afterMemberInfo.getName()).isEqualTo(request.name());
+    }
+
+    @Test
+    @DisplayName("[실패] 본인이 아니라면 마이페이지 정보를 수정할 수 없다.")
+    void updateMyPage_본인이_아니라면_마이페이지_정보를_수정할_수_없다_실패() {
+        final MyPageUpdateRequest request = new MyPageUpdateRequest("수정된 이름");
+        final Member otherMember = memberRepository.save(미나());
+
+        assertThatThrownBy(() -> {
+            memberCommandService.updateMyPage(request, member.getId(), otherMember.getId());
+        }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
     }
 }

--- a/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -158,5 +159,19 @@ public class MemberApiDocsTest extends RestDocsTest {
                         .header(HttpHeaders.AUTHORIZATION, accessToken))
                 .andExpect(status().isNoContent())
                 .andDo(document("myPage-image-update", requestParts, pathParameters));
+    }
+
+    @Test
+    @DisplayName("[성공] 마이페이지의 이미지를 삭제한다.")
+    public void deleteMyPageImage_마이페이지의_이미지를_삭제한다_성공() throws Exception {
+        doNothing().when(memberCommandService).deleteMyPageImage(any(), any());
+
+        final PathParametersSnippet pathParameters = pathParameters(
+                parameterWithName("memberId").description("멤버 id")
+        );
+        mockMvc.perform(delete("/myPage/members/{memberId}/image", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken))
+                .andExpect(status().isNoContent())
+                .andDo(document("myPage-image-delete", pathParameters));
     }
 }

--- a/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
@@ -5,10 +5,13 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import doore.member.application.dto.response.MemberAndMyTeamsAndStudiesResponse;
@@ -22,9 +25,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.restdocs.request.PathParametersSnippet;
+import org.springframework.restdocs.request.RequestPartsSnippet;
+import org.springframework.web.multipart.MultipartFile;
 
 public class MemberApiDocsTest extends RestDocsTest {
     private String accessToken;
@@ -127,5 +133,30 @@ public class MemberApiDocsTest extends RestDocsTest {
                                 stringFieldWithPath("name", "수정할 이름")
                         )
                 ));
+    }
+
+    @Test
+    @DisplayName("[성공] 마이페이지의 이미지를 수정한다.")
+    public void updateMyPageImage_마이페이지의_이미지를_수정한다_성공() throws Exception {
+        final MockMultipartFile file = getMockImageFile();
+
+        doNothing().when(memberCommandService).updateMyPageImage(any(), any(MultipartFile.class), any());
+
+        final RequestPartsSnippet requestParts = requestParts(
+                partWithName("file").description("마이페이지 프로필 이미지 파일")
+        );
+        final PathParametersSnippet pathParameters = pathParameters(
+                parameterWithName("memberId").description("멤버 id")
+        );
+        mockMvc.perform(multipart("/myPage/members/{memberId}/image", 1L)
+                        .file(file)
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        })
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken))
+                .andExpect(status().isNoContent())
+                .andDo(document("myPage-image-update", requestParts, pathParameters));
     }
 }

--- a/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
@@ -122,14 +122,11 @@ public class MemberApiDocsTest extends RestDocsTest {
     public void updateMyPage_마이페이지를_수정한다_성공() throws Exception {
         final MyPageUpdateRequest request = new MyPageUpdateRequest("수정된 이름");
 
-        mockMvc.perform(RestDocumentationRequestBuilders.patch("/myPage/members/{memberId}", 1)
+        mockMvc.perform(RestDocumentationRequestBuilders.patch("/members/me", 1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNoContent())
                 .andDo(document("myPage-update",
-                        pathParameters(
-                                parameterWithName("memberId").description("멤버 id")
-                        ),
                         requestFields(
                                 stringFieldWithPath("name", "수정할 이름")
                         )
@@ -141,15 +138,13 @@ public class MemberApiDocsTest extends RestDocsTest {
     public void updateMyPageImage_마이페이지의_이미지를_수정한다_성공() throws Exception {
         final MockMultipartFile file = getMockImageFile();
 
-        doNothing().when(memberCommandService).updateMyPageImage(any(), any(MultipartFile.class), any());
+        doNothing().when(memberCommandService).updateMyPageImage(any(MultipartFile.class), any());
 
         final RequestPartsSnippet requestParts = requestParts(
                 partWithName("file").description("마이페이지 프로필 이미지 파일")
         );
-        final PathParametersSnippet pathParameters = pathParameters(
-                parameterWithName("memberId").description("멤버 id")
-        );
-        mockMvc.perform(multipart("/myPage/members/{memberId}/image", 1L)
+
+        mockMvc.perform(multipart("/members/me/image", 1L)
                         .file(file)
                         .with(request -> {
                             request.setMethod("PATCH");
@@ -158,20 +153,17 @@ public class MemberApiDocsTest extends RestDocsTest {
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .header(HttpHeaders.AUTHORIZATION, accessToken))
                 .andExpect(status().isNoContent())
-                .andDo(document("myPage-image-update", requestParts, pathParameters));
+                .andDo(document("myPage-image-update", requestParts));
     }
 
     @Test
     @DisplayName("[성공] 마이페이지의 이미지를 삭제한다.")
     public void deleteMyPageImage_마이페이지의_이미지를_삭제한다_성공() throws Exception {
-        doNothing().when(memberCommandService).deleteMyPageImage(any(), any());
+        doNothing().when(memberCommandService).deleteMyPageImage(any());
 
-        final PathParametersSnippet pathParameters = pathParameters(
-                parameterWithName("memberId").description("멤버 id")
-        );
-        mockMvc.perform(delete("/myPage/members/{memberId}/image", 1L)
+        mockMvc.perform(delete("/members/me/image", 1L)
                         .header(HttpHeaders.AUTHORIZATION, accessToken))
                 .andExpect(status().isNoContent())
-                .andDo(document("myPage-image-delete", pathParameters));
+                .andDo(document("myPage-image-delete"));
     }
 }

--- a/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
@@ -5,12 +5,14 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import doore.member.application.dto.response.MemberAndMyTeamsAndStudiesResponse;
+import doore.member.application.dto.response.MyPageUpdateRequest;
 import doore.restdocs.RestDocsTest;
 import doore.study.application.dto.response.StudyNameResponse;
 import doore.team.application.dto.response.MyTeamsAndStudiesResponse;
@@ -106,5 +108,24 @@ public class MemberApiDocsTest extends RestDocsTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(document("get-sidebar-info", pathParameters, responseFieldsSnippet));
+    }
+
+    @Test
+    @DisplayName("[성공] 마이페이지를 수정한다.")
+    public void updateMyPage_마이페이지를_수정한다_성공() throws Exception {
+        final MyPageUpdateRequest request = new MyPageUpdateRequest("수정된 이름");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.patch("/myPage/members/{memberId}", 1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("myPage-update",
+                        pathParameters(
+                                parameterWithName("memberId").description("멤버 id")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("name", "수정할 이름")
+                        )
+                ));
     }
 }

--- a/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/MemberApiDocsTest.java
@@ -16,7 +16,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.requestP
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import doore.member.application.dto.response.MemberAndMyTeamsAndStudiesResponse;
-import doore.member.application.dto.response.MyPageUpdateRequest;
+import doore.member.application.dto.request.MyPageUpdateRequest;
 import doore.restdocs.RestDocsTest;
 import doore.study.application.dto.response.StudyNameResponse;
 import doore.team.application.dto.response.MyTeamsAndStudiesResponse;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #277

## 📝 작업 내용

- 마이페이지 프로필 이미지 삭제 api 개발

## 💬 리뷰 요구사항

- 앞선 pr에 언급한 것처럼 코드 중복 때문에 내용이 중복되도록 작성했습니다..!
- 그리고 default 이미지 경로에 관해서는 새로 저장한 이미지 경로를 알려주셔도 되고, 아니면 나중에 application.yml 정리하실 때 알맞게 수정하셔도 좋을 것 같습니다!
