### PR TITLE
Feature/#280 학습자료 정보에 업로더의 member id 추가

### DIFF
--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -14,6 +14,7 @@ import doore.document.exception.DocumentException;
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.application.convenience.TeamRoleValidateAccessPermission;
+import doore.member.domain.Member;
 import doore.study.application.convenience.StudyConvenience;
 import doore.study.domain.Study;
 import java.util.List;
@@ -62,9 +63,8 @@ public class DocumentQueryService {
                 .map(file -> new FileResponse(file.getId(), file.getName(), file.getUrl()))
                 .toList();
 
-        final String uploaderName = memberValidateAccessPermission.getValidateExistMember(document.getUploaderId())
-                .getName();
+        final Member member = memberValidateAccessPermission.getValidateExistMember(document.getUploaderId());
 
-        return DocumentResponse.of(document, fileResponses, uploaderName);
+        return DocumentResponse.of(document, fileResponses, member.getName(), member.getId());
     }
 }

--- a/src/main/java/doore/document/application/dto/response/DocumentResponse.java
+++ b/src/main/java/doore/document/application/dto/response/DocumentResponse.java
@@ -16,10 +16,11 @@ public record DocumentResponse(
         DocumentType type,
         List<FileResponse> files,
         LocalDate date,
-        String uploaderName
+        String uploaderName,
+        Long uploaderMemberId
 ) {
     public static DocumentResponse of(final Document document, final List<FileResponse> fileResponses,
-                                      final String uploaderName) {
+                                      final String uploaderName, final Long uploaderMemberId) {
         return DocumentResponse
                 .builder()
                 .id(document.getId())
@@ -30,6 +31,7 @@ public record DocumentResponse(
                 .files(fileResponses)
                 .date(document.getCreatedAt().toLocalDate())
                 .uploaderName(uploaderName)
+                .uploaderMemberId(uploaderMemberId)
                 .build();
     }
 }

--- a/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
+++ b/src/test/java/doore/restdocs/docs/DocumentDocsTest.java
@@ -107,9 +107,10 @@ public class DocumentDocsTest extends RestDocsTest {
                 .files(List.of(fileResponse))
                 .date(LocalDate.parse("2024-02-28"))
                 .uploaderName("김땡땡")
+                .uploaderMemberId(2L)
                 .build();
         final DocumentResponse otherDocument = DocumentResponse.builder()
-                .id(1L)
+                .id(2L)
                 .title("학습자료")
                 .description("학습자료 입니다.")
                 .accessType(ALL)
@@ -117,9 +118,11 @@ public class DocumentDocsTest extends RestDocsTest {
                 .files(List.of(fileResponse))
                 .date(LocalDate.parse("2024-02-28"))
                 .uploaderName("김땡땡")
+                .uploaderMemberId(3L)
                 .build();
         final List<DocumentResponse> documents = List.of(document, otherDocument);
-        final Page<DocumentResponse> documentResponsePage = new PageImpl<>(documents, PageRequest.of(0,4),documents.size());
+        final Page<DocumentResponse> documentResponsePage = new PageImpl<>(documents, PageRequest.of(0, 4),
+                documents.size());
         //when
         when(documentQueryService.getAllDocument(any(), any(), any(PageRequest.class)))
                 .thenReturn(documentResponsePage);
@@ -155,6 +158,7 @@ public class DocumentDocsTest extends RestDocsTest {
                 .files(List.of(fileResponse))
                 .date(LocalDate.parse("2024-02-28"))
                 .uploaderName("김땡땡")
+                .uploaderMemberId(2L)
                 .build();
 
         //when
@@ -177,7 +181,8 @@ public class DocumentDocsTest extends RestDocsTest {
                                 stringFieldWithPath("files[].name", "첨부파일명"),
                                 stringFieldWithPath("files[].url", "첨부파일 URL"),
                                 stringFieldWithPath("date", "학습자료 업로드 날짜"),
-                                stringFieldWithPath("uploaderName", "학습자료 업로더 이름")
+                                stringFieldWithPath("uploaderName", "학습자료 업로더 이름"),
+                                numberFieldWithPath("uploaderMemberId", "학습자료 업로더 member ID")
                         )
                 ));
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #280 

## 📝 작업 내용

- uploaderName으로 자료를 구분할 경우 동명이인에 대한 처리가 어렵다고 판단되어, 학습자료 response에 (DocumentResponse)에 memberId를 추가하였습니다!

## 💬 리뷰 요구사항

- 없어요~!~!~~!
