### PR TITLE
Feature/#288 팀 공개 학습자료가 팀원에게 보이지 않는 문제 수정

### DIFF
--- a/src/main/java/doore/document/api/DocumentController.java
+++ b/src/main/java/doore/document/api/DocumentController.java
@@ -63,7 +63,9 @@ public class DocumentController {
         return ResponseEntity.status(HttpStatus.OK).body(documents);
     }
 
-    @GetMapping("/{documentId}")  // 팀 학습자료 -> 비회원, 스터디 학습자료 -> 스터디 구성원
+    @GetMapping("/{documentId}")
+    // 팀 학습자료 - 전체 공개 -> 회원 이상, 팀 학습자료 - 팀 공개 -> 팀원 이상, 스터디 학습자료 -> 스터디 구성원
+    // DocumentGroupType 의 STUDY(studies)는 기획 상 삭제
     public ResponseEntity<DocumentResponse> getDocument(@PathVariable final Long documentId,
                                                         @LoginMember final Member member) {
         final DocumentResponse response = documentQueryService.getDocument(documentId, member.getId());

--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -49,11 +49,11 @@ public class DocumentQueryService {
         final Document document = documentRepository.findById(documentId)
                 .orElseThrow(() -> new DocumentException(NOT_FOUND_DOCUMENT));
         final DocumentGroupType documentGroupType = document.getGroupType();
-        final Study study = studyConvenience.findByDocumentId(documentId);
         if (documentGroupType == STUDY) {
+            final Study study = studyConvenience.findByDocumentId(documentId);
             studyRoleValidateAccessPermission.validateExistParticipant(study.getId(), memberId);
         } else if (documentGroupType == TEAM && document.getAccessType() == DocumentAccessType.TEAM) {
-            teamRoleValidateAccessPermission.validateExistMemberTeam(study.getTeamId(), memberId);
+            teamRoleValidateAccessPermission.validateExistMemberTeam(document.getGroupId(), memberId);
         }
         return toDocumentResponse(document);
     }

--- a/src/test/java/doore/document/application/DocumentQueryServiceTest.java
+++ b/src/test/java/doore/document/application/DocumentQueryServiceTest.java
@@ -197,8 +197,8 @@ public class DocumentQueryServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[실패] 팀원은 팀 학습자료 상세 조회를 할 수 없다.")
-    public void getDocument_회원은_팀_학습자료_상세_조회를_할_수_없다_실패() {
+    @DisplayName("[실패] 팀원은 스터디 학습자료 상세 조회를 할 수 없다.")
+    public void getDocument_팀원은_스터디_학습자료_상세_조회를_할_수_없다_실패() {
         assertThatThrownBy(
                 () -> documentQueryService.getDocument(studyDocument.getId(), notParticipantMember.getId()))
                 .isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #288

## 📝 작업 내용

- 팀 공개 학습자료가 팀원에게 보이지 않는 문제를 수정하였습니다.
    - 팀 공개 학습자료 팀원 검증 시 `study`로 부터 가져온 `teamId`를 통해 검증하고 있었습니다.
    - 따라서 스터디 학습자료가 아니면 `team`을 찾을 수 없는 상황이 발생하였습니다.
    - 이것을 `document`의 `groupId`로 수정하여 문제를 해결하였습니다.

## 💬 리뷰 요구사항

- 부끄럽네요,, 완전 제 실수였습니당,,