### PR TITLE
Feature/#294 스터디 개수를 제한한다

### DIFF
--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -1,5 +1,6 @@
 package doore.study.application;
 
+import static doore.study.exception.StudyExceptionType.CANNOT_CREATE_STUDY;
 import static doore.study.exception.StudyExceptionType.INVALID_ENDDATE;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STATUS;
 
@@ -47,6 +48,7 @@ public class StudyCommandService {
     public void createStudy(final StudyCreateRequest request, final Long teamId, final Long memberId) {
         teamRoleValidateAccessPermission.validateExistMemberTeam(teamId, memberId);
         teamValidateAccessPermission.validateExistTeam(teamId);
+        checkStudyCount(teamId);
         checkEndDateValid(request.startDate(), request.endDate());
 
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
@@ -87,6 +89,13 @@ public class StudyCommandService {
             study.changeStatus(changedStatus);
         } catch (final IllegalArgumentException e) {
             throw new StudyException(NOT_FOUND_STATUS);
+        }
+    }
+
+    private void checkStudyCount(final Long teamId) {
+        final List<Study> studies = studyRepository.findAllByTeamId(teamId);
+        if (studies.size() >= 99) {
+            throw new StudyException(CANNOT_CREATE_STUDY);
         }
     }
 

--- a/src/main/java/doore/study/exception/StudyExceptionType.java
+++ b/src/main/java/doore/study/exception/StudyExceptionType.java
@@ -8,6 +8,7 @@ public enum StudyExceptionType implements BaseExceptionType {
     NOT_FOUND_STATUS(HttpStatus.BAD_REQUEST, "존재하지 않는 스터디 상태입니다."),
     INVALID_ENDDATE(HttpStatus.BAD_REQUEST, "시작일보다 빠른 날짜에 종료할 수 없습니다."),
     NOT_FOUND_PARTICIPANT(HttpStatus.NOT_FOUND,"참여자를 찾을 수 없습니다."),
+    CANNOT_CREATE_STUDY(HttpStatus.BAD_REQUEST, "스터디 생성 제한 개수를 초과하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/doore/study/application/StudyCommandServiceTest.java
+++ b/src/test/java/doore/study/application/StudyCommandServiceTest.java
@@ -11,6 +11,7 @@ import static doore.study.StudyFixture.algorithmStudy;
 import static doore.study.domain.StudyStatus.ENDED;
 import static doore.study.domain.StudyStatus.IN_PROGRESS;
 import static doore.study.domain.StudyStatus.UPCOMING;
+import static doore.study.exception.StudyExceptionType.CANNOT_CREATE_STUDY;
 import static doore.study.exception.StudyExceptionType.INVALID_ENDDATE;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STATUS;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
@@ -48,8 +49,10 @@ import doore.team.domain.Team;
 import doore.team.domain.repository.TeamRepository;
 import doore.team.exception.TeamException;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -86,7 +89,7 @@ public class StudyCommandServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        member =  memberRepository.save(미나());
+        member = memberRepository.save(미나());
         memberId = member.getId();
         study = studyRepository.save(algorithmStudy());
         studyRole = studyRoleRepository.save(StudyRole.builder()
@@ -196,6 +199,28 @@ public class StudyCommandServiceTest extends IntegrationTest {
                 assertThatThrownBy(() -> {
                     studyCommandService.createStudy(studyCreateRequest, team.getId(), notTeamMemberId);
                 }).isInstanceOf(MemberException.class).hasMessage(UNAUTHORIZED.errorMessage());
+            }
+
+            @Test
+            @DisplayName("[실패] 스터디 개수가 99개를 초과하면 스터디 생성은 불가하다.")
+            void createStudy_스터디_개수가_99개를_초과하면_스터디_생성은_불가하다_실패() throws Exception {
+                IntStream.range(0, 99)
+                        .forEach(i -> studyRepository.save(Study.builder()
+                                .name("알고리즘")
+                                .description("알고리즘 스터디 입니다.")
+                                .startDate(LocalDate.parse("2025-01-01"))
+                                .endDate(LocalDate.parse("2026-01-01"))
+                                .teamId(team.getId())
+                                .status(IN_PROGRESS)
+                                .isDeleted(false)
+                                .cropId(1L)
+                                .curriculumItems(new ArrayList<CurriculumItem>())
+                                .build()));
+
+                assertThatThrownBy(
+                        () -> studyCommandService.createStudy(studyCreateRequest, team.getId(), memberId))
+                        .isInstanceOf(StudyException.class)
+                        .hasMessage(CANNOT_CREATE_STUDY.errorMessage());
             }
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #294

## 📝 작업 내용

- 스터디 정렬을 service에서 진행하기 때문에 부하를 막기 위해 스터디 생성 개수를 99개로 제한하였습니다.

## 💬 리뷰 요구사항

- 테스트에서 스터디를 builder로 생성한 이유는, Fixture를 사용하면 제가 생각했던 team에 저장되지 않아서 정확히 team을 명시하고자 builder로 생성하였습니다.