### PR TITLE
Feature/#240 스터디원 중복 추가 불가 기능 추가

### DIFF
--- a/src/main/java/doore/member/domain/repository/ParticipantRepository.java
+++ b/src/main/java/doore/member/domain/repository/ParticipantRepository.java
@@ -15,4 +15,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     List<Participant> findByMemberId(Long memberId);
 
     void deleteByStudyIdAndMemberId(Long studyId, Long memberId);
+
+    boolean existsByStudyIdAndMemberIdAndIsDeletedFalse(Long studyId, Long memberId);
+
 }

--- a/src/main/java/doore/member/exception/ParticipantExceptionType.java
+++ b/src/main/java/doore/member/exception/ParticipantExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum ParticipantExceptionType implements BaseExceptionType {
 
     CANNOT_DELETE_STUDY_LEADER_SELF(HttpStatus.BAD_REQUEST, "스터디장 본인은 팀을 탈퇴할 수 없습니다."),
+    ALREADY_JOINED_STUDY(HttpStatus.BAD_REQUEST, "이미 참여중인 스터디입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/study/application/ParticipantCommandService.java
+++ b/src/main/java/doore/study/application/ParticipantCommandService.java
@@ -1,6 +1,7 @@
 package doore.study.application;
 
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+import static doore.member.exception.ParticipantExceptionType.ALREADY_JOINED_STUDY;
 import static doore.member.exception.ParticipantExceptionType.CANNOT_DELETE_STUDY_LEADER_SELF;
 
 import doore.member.application.convenience.MemberConvenience;
@@ -38,6 +39,7 @@ public class ParticipantCommandService {
 
     public void createParticipant(final Long studyId, final Long memberId, final Long studyLeaderId) {
         studyRoleValidateAccessPermission.validateExistStudyLeader(studyId, studyLeaderId);
+        isAlreadyExistParticipant(studyId, memberId);
         final Study study = studyValidateAccessPermission.getValidateExistStudy(studyId);
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         final Long teamId = study.getTeamId();
@@ -100,6 +102,12 @@ public class ParticipantCommandService {
                     return true;
                 })
                 .orElse(false);
+    }
+
+    private void isAlreadyExistParticipant(final Long studyId, final Long memberId) {
+        if (participantRepository.existsByStudyIdAndMemberIdAndIsDeletedFalse(studyId, memberId)) {
+            throw new ParticipantException(ALREADY_JOINED_STUDY);
+        }
     }
 
 }

--- a/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
+++ b/src/test/java/doore/study/application/ParticipantCommandServiceTest.java
@@ -8,6 +8,7 @@ import static doore.member.domain.StudyRoleType.ROLE_스터디장;
 import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+import static doore.member.exception.ParticipantExceptionType.ALREADY_JOINED_STUDY;
 import static doore.member.exception.ParticipantExceptionType.CANNOT_DELETE_STUDY_LEADER_SELF;
 import static doore.study.StudyFixture.algorithmStudy;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import doore.helper.IntegrationTest;
+import doore.member.MemberFixture;
 import doore.member.domain.Member;
 import doore.member.domain.Participant;
 import doore.member.domain.StudyRole;
@@ -103,6 +105,35 @@ public class ParticipantCommandServiceTest extends IntegrationTest {
                     () -> assertThat(participantResponses).hasSize(1),
                     () -> assertEquals(memberId, participantResponses.get(0).memberId())
             );
+        }
+
+        @Test
+        @DisplayName("[실패] 이미 스터디에 가입되어 있다면 참여자 추가는 실패한다.")
+        void createParticipant_이미_스터디에_가입되어_있다면_참여자_추가는_실패한다_실패() {
+            participantCommandService.createParticipant(study.getId(), member.getId(), member.getId());
+
+            assertThatThrownBy(
+                    () -> participantCommandService.createParticipant(study.getId(), member.getId(),
+                            member.getId()))
+                    .isInstanceOf(ParticipantException.class).hasMessage(ALREADY_JOINED_STUDY.errorMessage());
+        }
+
+        @Test
+        @DisplayName("[성공] 스터디 탈퇴 후 스터디 재참여 시 참여자 추가 가능하다.")
+        void createParticipant_스터디_탈퇴_후_스터디_재참여_시_참여자_추가_가능하다_성공() {
+            final Member anotherMember = memberRepository.save(MemberFixture.아마스());
+            teamRoleRepository.save(TeamRole.builder()
+                    .memberId(anotherMember.getId())
+                    .teamRoleType(ROLE_팀원)
+                    .teamId(study.getTeamId())
+                    .build());
+
+            participantCommandService.createParticipant(study.getId(), anotherMember.getId(), member.getId());
+            participantCommandService.withdrawParticipant(study.getId(), anotherMember.getId());
+
+            participantCommandService.createParticipant(study.getId(), anotherMember.getId(), member.getId());
+
+            assertThat(participantRepository.count()).isEqualTo(2);
         }
 
         @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #240 

## 📝 작업 내용

- 스터디원 중복 추가가 불가하도록 변경하였습니다.
    -  단, 스터디 참여 -> 스터디 탈퇴 -> 스터디 재참여는 가능하도록 하였습니다.
