### PR TITLE
Feature/#300 팀장이라면 회원 탈퇴 불가하도록 변경

### DIFF
--- a/src/main/java/doore/member/application/MemberCommandService.java
+++ b/src/main/java/doore/member/application/MemberCommandService.java
@@ -2,9 +2,9 @@ package doore.member.application;
 
 import doore.file.application.S3ImageFileService;
 import doore.login.application.dto.response.GoogleAccountProfileResponse;
-import doore.member.application.convenience.MemberConvenience;
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
+import doore.member.application.convenience.TeamRoleConvenience;
 import doore.member.application.convenience.TeamRoleValidateAccessPermission;
 import doore.member.application.dto.request.MyPageUpdateRequest;
 import doore.member.domain.Member;
@@ -12,7 +12,10 @@ import doore.member.domain.StudyRole;
 import doore.member.domain.TeamRole;
 import doore.member.domain.repository.MemberRepository;
 import doore.study.application.convenience.StudyValidateAccessPermission;
+import doore.team.application.convenience.TeamConvenience;
 import doore.team.application.convenience.TeamValidateAccessPermission;
+import doore.team.domain.Team;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +28,8 @@ public class MemberCommandService {
 
     private final MemberRepository memberRepository;
 
-    private final MemberConvenience memberConvenience;
+    private final TeamConvenience teamConvenience;
+    private final TeamRoleConvenience teamRoleConvenience;
 
     private final S3ImageFileService s3ImageFileService;
 
@@ -75,6 +79,8 @@ public class MemberCommandService {
 
     public void deleteMember(final Long memberId) {
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
+        List<Team> teams = teamConvenience.findAllByMemberId(memberId);
+        teamRoleConvenience.isTeamLeader(teams, memberId);
         memberRepository.delete(member);
     }
 

--- a/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
@@ -2,13 +2,14 @@ package doore.member.application.convenience;
 
 import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.member.domain.StudyRoleType.ROLE_스터디장;
-import static doore.member.exception.MemberExceptionType.CANNOT_DELETE_STUDY_LEADER;
 import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER_ROLE_IN_STUDY;
+import static doore.member.exception.MemberTeamExceptionType.CANNOT_DELETE_STUDY_LEADER;
 
 import doore.member.domain.StudyRole;
 import doore.member.domain.StudyRoleType;
 import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.exception.MemberException;
+import doore.member.exception.MemberTeamException;
 import doore.study.domain.Study;
 import java.util.List;
 import java.util.Optional;
@@ -60,7 +61,7 @@ public class StudyRoleConvenience {
         if (!leaderStudyNames.isEmpty()) {
             String joinedNames = String.join(", ", leaderStudyNames);
             String formattedMessage = String.format(CANNOT_DELETE_STUDY_LEADER.errorMessage(), joinedNames);
-            throw new MemberException(CANNOT_DELETE_STUDY_LEADER, formattedMessage);
+            throw new MemberTeamException(CANNOT_DELETE_STUDY_LEADER, formattedMessage);
         }
     }
 

--- a/src/main/java/doore/member/application/convenience/TeamRoleConvenience.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleConvenience.java
@@ -2,9 +2,13 @@ package doore.member.application.convenience;
 
 import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
+import static doore.member.exception.MemberExceptionType.CANNOT_DELETE_TEAM_LEADER;
 
 import doore.member.domain.TeamRole;
 import doore.member.domain.repository.TeamRoleRepository;
+import doore.member.exception.MemberException;
+import doore.team.domain.Team;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,5 +37,19 @@ public class TeamRoleConvenience {
 
     public void deleteByTeamIdAndMemberId(final Long teamId, final Long memberId) {
         teamRoleRepository.deleteByTeamIdAndMemberId(teamId, memberId);
+    }
+
+    public void isTeamLeader(final List<Team> teams, final Long memberId) {
+        final List<String> leaderTeamNames = teams.stream()
+                .filter(team -> teamRoleRepository.existsByTeamIdAndMemberIdAndTeamRoleType(
+                        team.getId(), memberId, ROLE_팀장))
+                .map(Team::getName)
+                .toList();
+
+        if (!leaderTeamNames.isEmpty()) {
+            String joinedNames = String.join(", ", leaderTeamNames);
+            String formattedMessage = String.format(CANNOT_DELETE_TEAM_LEADER.errorMessage(), joinedNames);
+            throw new MemberException(CANNOT_DELETE_TEAM_LEADER, formattedMessage);
+        }
     }
 }

--- a/src/main/java/doore/member/domain/repository/TeamRoleRepository.java
+++ b/src/main/java/doore/member/domain/repository/TeamRoleRepository.java
@@ -15,4 +15,5 @@ public interface TeamRoleRepository extends JpaRepository<TeamRole, Long> {
     Long findLeaderIdByTeamId(Long teamId);
     List<TeamRole> findAllByTeamId(final Long teamId);
     void deleteByTeamIdAndMemberId(final Long teamId, final Long memberId);
+    boolean existsByTeamIdAndMemberIdAndTeamRoleType(Long teamId, Long memberId, TeamRoleType teamRoleType);
 }

--- a/src/main/java/doore/member/exception/MemberExceptionType.java
+++ b/src/main/java/doore/member/exception/MemberExceptionType.java
@@ -12,7 +12,6 @@ public enum MemberExceptionType implements BaseExceptionType {
     NOT_FOUND_MEMBER_IN_STUDY(HttpStatus.NOT_FOUND, "스터디 내 해당 회원을 찾을 수 없습니다."),
     ALREADY_JOIN_TEAM_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 팀원입니다."),
     ALREADY_JOIN_STUDY_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 스터디원입니다."),
-    CANNOT_DELETE_STUDY_LEADER(HttpStatus.BAD_REQUEST, "스터디장을 맡고 있다면 팀원 삭제가 불가능합니다.(%s)"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/member/exception/MemberExceptionType.java
+++ b/src/main/java/doore/member/exception/MemberExceptionType.java
@@ -12,6 +12,7 @@ public enum MemberExceptionType implements BaseExceptionType {
     NOT_FOUND_MEMBER_IN_STUDY(HttpStatus.NOT_FOUND, "스터디 내 해당 회원을 찾을 수 없습니다."),
     ALREADY_JOIN_TEAM_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 팀원입니다."),
     ALREADY_JOIN_STUDY_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 스터디원입니다."),
+    CANNOT_DELETE_TEAM_LEADER(HttpStatus.BAD_REQUEST, "팀장을 맡고 있다면 회원 탈퇴가 불가능합니다.(%s)"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/member/exception/MemberTeamException.java
+++ b/src/main/java/doore/member/exception/MemberTeamException.java
@@ -11,6 +11,11 @@ public class MemberTeamException extends BaseException {
         this.exceptionType = exceptionType;
     }
 
+    public MemberTeamException(final MemberTeamExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
     @Override
     public BaseExceptionType exceptionType() {
         return exceptionType;

--- a/src/main/java/doore/member/exception/MemberTeamExceptionType.java
+++ b/src/main/java/doore/member/exception/MemberTeamExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum MemberTeamExceptionType implements BaseExceptionType {
 
     CANNOT_DELETE_TEAM_LEADER_SELF(HttpStatus.BAD_REQUEST, "팀장 본인은 팀을 탈퇴할 수 없습니다."),
+    CANNOT_DELETE_STUDY_LEADER(HttpStatus.BAD_REQUEST, "스터디장을 맡고 있다면 팀원 삭제가 불가능합니다.(%s)"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/doore/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/doore/team/application/convenience/TeamConvenience.java
@@ -1,0 +1,20 @@
+package doore.team.application.convenience;
+
+import doore.team.domain.Team;
+import doore.team.domain.repository.TeamRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TeamConvenience {
+
+    private final TeamRepository teamRepository;
+
+    public List<Team> findAllByMemberId(final Long memberId) {
+        return teamRepository.findAllByMemberId(memberId);
+    }
+}

--- a/src/test/java/doore/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberCommandServiceTest.java
@@ -6,6 +6,7 @@ import static doore.member.domain.StudyRoleType.ROLE_스터디원;
 import static doore.member.domain.StudyRoleType.ROLE_스터디장;
 import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
+import static doore.member.exception.MemberExceptionType.CANNOT_DELETE_TEAM_LEADER;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,9 +17,11 @@ import doore.helper.IntegrationTest;
 import doore.login.application.dto.response.GoogleAccountProfileResponse;
 import doore.member.application.dto.request.MyPageUpdateRequest;
 import doore.member.domain.Member;
+import doore.member.domain.MemberTeam;
 import doore.member.domain.StudyRole;
 import doore.member.domain.TeamRole;
 import doore.member.domain.repository.MemberRepository;
+import doore.member.domain.repository.MemberTeamRepository;
 import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.domain.repository.TeamRoleRepository;
 import doore.member.exception.MemberException;
@@ -47,9 +50,12 @@ class MemberCommandServiceTest extends IntegrationTest {
     private TeamRoleRepository teamRoleRepository;
     @Autowired
     private StudyRoleRepository studyRoleRepository;
+    @Autowired
+    private MemberTeamRepository memberTeamRepository;
 
     private Member member;
     private Team team;
+    private MemberTeam memberTeam;
     private Study study;
     private TeamRole previousTeamLeaderRole;
     private StudyRole previousStudyLeaderRole;
@@ -59,6 +65,10 @@ class MemberCommandServiceTest extends IntegrationTest {
         member = memberRepository.save(아마란스());
         team = teamRepository.save(TeamFixture.team());
         study = studyRepository.save(StudyFixture.algorithmStudy());
+        memberTeam = memberTeamRepository.save(MemberTeam.builder()
+                .teamId(team.getId())
+                .member(member)
+                .build());
         previousTeamLeaderRole = TeamRole.builder()
                 .teamId(team.getId())
                 .teamRoleType(ROLE_팀장)
@@ -244,4 +254,13 @@ class MemberCommandServiceTest extends IntegrationTest {
         assertThat(afterMemberInfo.getName()).isEqualTo(request.name());
     }
 
+    @Test
+    @DisplayName("[실패] 팀장을 맡고 있다면 회원 탈퇴는 불가하다.")
+    void deleteMember_팀장을_맡고_있다면_회원_탈퇴는_불가하다_실패() {
+        final String expectedMessage = String.format(CANNOT_DELETE_TEAM_LEADER.errorMessage(), "BDD");
+
+        assertThatThrownBy(() -> {
+            memberCommandService.deleteMember(member.getId());
+        }).isInstanceOf(MemberException.class).hasMessage(expectedMessage);
+    }
 }

--- a/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberTeamCommandServiceTest.java
@@ -6,8 +6,8 @@ import static doore.member.MemberFixture.아마란스;
 import static doore.member.MemberFixture.짱구;
 import static doore.member.domain.TeamRoleType.ROLE_팀원;
 import static doore.member.domain.TeamRoleType.ROLE_팀장;
-import static doore.member.exception.MemberExceptionType.CANNOT_DELETE_STUDY_LEADER;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
+import static doore.member.exception.MemberTeamExceptionType.CANNOT_DELETE_STUDY_LEADER;
 import static doore.member.exception.MemberTeamExceptionType.CANNOT_DELETE_TEAM_LEADER_SELF;
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.team.TeamFixture.team;
@@ -163,7 +163,7 @@ public class MemberTeamCommandServiceTest extends IntegrationTest {
 
         assertThatThrownBy(() -> {
             memberTeamCommandService.deleteMemberTeam(team.getId(), studyLeaderMember.getId(), teamLeader.getId());
-        }).isInstanceOf(MemberException.class).hasMessage(expectedMessage);
+        }).isInstanceOf(MemberTeamException.class).hasMessage(expectedMessage);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #300

## 📝 작업 내용

- 팀장을 맡고 있는 팀원의 회원 탈퇴가 불가능하도록 변경합니다.
- 어떤 팀의 팀장을 맡고 있는지에 대한 정보를 에러 메시지로 전달합니다.
