### PR TITLE
Feature/#299 스터디 상태가 항상 upcoming 으로 가는 문제 해결

### DIFF
--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -91,7 +91,8 @@ public class StudyCommandService {
     }
 
     private void checkEndDateValid(final LocalDate startDate, final LocalDate endDate) {
-        if (endDate != null && startDate.isAfter(endDate)) {
+        final LocalDate now = LocalDate.now();
+        if (endDate != null && (startDate.isAfter(endDate) || endDate.isBefore(now))) {
             throw new StudyException(INVALID_ENDDATE);
         }
     }

--- a/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
+++ b/src/main/java/doore/study/application/dto/request/StudyCreateRequest.java
@@ -1,9 +1,11 @@
 package doore.study.application.dto.request;
 
+import static doore.study.domain.StudyStatus.IN_PROGRESS;
 import static doore.study.domain.StudyStatus.UPCOMING;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import doore.study.domain.Study;
+import doore.study.domain.StudyStatus;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -38,12 +40,20 @@ public record StudyCreateRequest(
     }
 
     public Study toStudy(final Long teamId) {
+        final LocalDate now = LocalDate.now();
+        final StudyStatus status;
+
+        if (now.isBefore(this.startDate)) status = UPCOMING;
+        else if (this.endDate != null
+                && (!now.isBefore(this.startDate) && !now.isAfter(this.endDate))) status = IN_PROGRESS;
+        else status = IN_PROGRESS;
+
         return Study.builder()
                 .name(this.name)
                 .description(this.description)
                 .startDate(this.startDate)
                 .endDate(this.endDate)
-                .status(UPCOMING)
+                .status(status)
                 .isDeleted(false)
                 .teamId(teamId)
                 .cropId(this.cropId)

--- a/src/test/java/doore/study/StudyFixture.java
+++ b/src/test/java/doore/study/StudyFixture.java
@@ -37,7 +37,7 @@ public class StudyFixture {
                 .name("알고리즘")
                 .description("알고리즘 스터디 입니다.")
                 .startDate(LocalDate.parse("2023-01-01"))
-                .endDate(LocalDate.parse("2024-01-01"))
+                .endDate(LocalDate.parse("2029-01-01"))
                 .teamId(teamId)
                 .status(IN_PROGRESS)
                 .isDeleted(false)

--- a/src/test/java/doore/study/api/StudyControllerTest.java
+++ b/src/test/java/doore/study/api/StudyControllerTest.java
@@ -73,7 +73,7 @@ public class StudyControllerTest extends IntegrationTest {
         void createStudy_정상적으로_스터디를_생성한다_성공() throws Exception {
             final String url = "/teams/" + team.getId() + "/studies";
             final StudyCreateRequest request = new StudyCreateRequest("알고리즘", "알고리즘 스터디 입니다.",
-                    LocalDate.parse("2020-01-01"), LocalDate.parse("2020-01-05"), 1L);
+                    LocalDate.parse("2020-01-01"), LocalDate.parse("2029-01-05"), 1L);
 
             callPostApi(url, request, token).andExpect(status().isCreated());
         }

--- a/src/test/java/doore/study/application/StudyCommandServiceTest.java
+++ b/src/test/java/doore/study/application/StudyCommandServiceTest.java
@@ -10,7 +10,6 @@ import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 import static doore.study.StudyFixture.algorithmStudy;
 import static doore.study.domain.StudyStatus.ENDED;
 import static doore.study.domain.StudyStatus.IN_PROGRESS;
-import static doore.study.domain.StudyStatus.UPCOMING;
 import static doore.study.exception.StudyExceptionType.INVALID_ENDDATE;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STATUS;
 import static doore.study.exception.StudyExceptionType.NOT_FOUND_STUDY;
@@ -148,7 +147,7 @@ public class StudyCommandServiceTest extends IntegrationTest {
                 final List<Study> studies = studyRepository.findAll();
                 final Study study = studies.get(1);
                 assertAll(
-                        () -> assertEquals(UPCOMING, study.getStatus()),
+                        () -> assertEquals(IN_PROGRESS, study.getStatus()),
                         () -> assertEquals(false, study.getIsDeleted())
                 );
 

--- a/src/test/java/doore/study/application/StudyCommandServiceTest.java
+++ b/src/test/java/doore/study/application/StudyCommandServiceTest.java
@@ -301,7 +301,7 @@ public class StudyCommandServiceTest extends IntegrationTest {
                     .name("스프링")
                     .description("스프링 스터디 입니다.")
                     .startDate(LocalDate.parse("2023-01-01"))
-                    .endDate(LocalDate.parse("2024-01-01"))
+                    .endDate(LocalDate.parse("2029-01-01"))
                     .status(IN_PROGRESS)
                     .build();
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #299

## 📝 작업 내용

- 스터디 생성 시 스터디 상태가 UPCOMING으로만 저장되던 로직을, 현재를 기준으로 알맞은 상태를 저장하도록 변경하였습니다.
    - startDate보다 현재 시점이 이전이라면 -> `UPCOMING`
    - endDate가 null이 아니고, startDate <= now <= endDate라면 -> `IN_PROGRESS`
    - endDate가 null인 경우 -> `IN_PROGRESS`
- 종료 시점이 스터디 생성 시점 이전인 스터디는 생성 불가하도록 변경하였습니다.
