### PR TITLE
Feature/#307 팀원이 회원탈퇴하면 팀원 조회가 불가한 문제 해결

### DIFF
--- a/src/main/java/doore/member/application/MemberCommandService.java
+++ b/src/main/java/doore/member/application/MemberCommandService.java
@@ -2,7 +2,9 @@ package doore.member.application;
 
 import doore.file.application.S3ImageFileService;
 import doore.login.application.dto.response.GoogleAccountProfileResponse;
+import doore.member.application.convenience.MemberTeamConvenience;
 import doore.member.application.convenience.MemberValidateAccessPermission;
+import doore.member.application.convenience.StudyRoleConvenience;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.application.convenience.TeamRoleConvenience;
 import doore.member.application.convenience.TeamRoleValidateAccessPermission;
@@ -11,6 +13,7 @@ import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
 import doore.member.domain.TeamRole;
 import doore.member.domain.repository.MemberRepository;
+import doore.study.application.convenience.ParticipantConvenience;
 import doore.study.application.convenience.StudyValidateAccessPermission;
 import doore.team.application.convenience.TeamConvenience;
 import doore.team.application.convenience.TeamValidateAccessPermission;
@@ -30,6 +33,9 @@ public class MemberCommandService {
 
     private final TeamConvenience teamConvenience;
     private final TeamRoleConvenience teamRoleConvenience;
+    private final MemberTeamConvenience memberTeamConvenience;
+    private final ParticipantConvenience participantConvenience;
+    private final StudyRoleConvenience studyRoleConvenience;
 
     private final S3ImageFileService s3ImageFileService;
 
@@ -81,6 +87,10 @@ public class MemberCommandService {
         final Member member = memberValidateAccessPermission.getValidateExistMember(memberId);
         List<Team> teams = teamConvenience.findAllByMemberId(memberId);
         teamRoleConvenience.isTeamLeader(teams, memberId);
+
+        deleteAboutTeam(memberId);
+        deleteAboutStudy(memberId);
+
         memberRepository.delete(member);
     }
 
@@ -108,6 +118,16 @@ public class MemberCommandService {
         if (member.hasImage()) {
             s3ImageFileService.deleteFile(member.getImageUrl());
         }
+    }
+
+    private void deleteAboutTeam(final Long memberId) {
+        memberTeamConvenience.deleteAllMemberTeams(memberId);
+        teamRoleConvenience.deleteAllTeamRoles(memberId);
+    }
+
+    private void deleteAboutStudy(final Long memberId) {
+        participantConvenience.deleteAllParticipantsByMemberId(memberId);
+        studyRoleConvenience.deleteAllStudyRoles(memberId);
     }
 
 }

--- a/src/main/java/doore/member/application/convenience/MemberTeamConvenience.java
+++ b/src/main/java/doore/member/application/convenience/MemberTeamConvenience.java
@@ -6,6 +6,7 @@ import doore.member.domain.Member;
 import doore.member.domain.MemberTeam;
 import doore.member.domain.repository.MemberTeamRepository;
 import doore.member.exception.MemberException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,5 +29,10 @@ public class MemberTeamConvenience {
                 .isDeleted(false)
                 .teamId(teamId)
                 .build());
+    }
+
+    public void deleteAllMemberTeams(final Long memberId) {
+        final List<MemberTeam> memberTeams = memberTeamRepository.findAllByMemberId(memberId);
+        memberTeamRepository.deleteAll(memberTeams);
     }
 }

--- a/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
+++ b/src/main/java/doore/member/application/convenience/StudyRoleConvenience.java
@@ -72,4 +72,9 @@ public class StudyRoleConvenience {
     public Optional<StudyRole> findStudyRoleByStudyIdAndMemberId(final Long studyId, final Long memberId) {
         return studyRoleRepository.findStudyRoleByStudyIdAndMemberId(studyId, memberId);
     }
+
+    public void deleteAllStudyRoles(final Long memberId) {
+        final List<StudyRole> studyRoles = studyRoleRepository.findAllByMemberId(memberId);
+        studyRoleRepository.deleteAll(studyRoles);
+    }
 }

--- a/src/main/java/doore/member/application/convenience/TeamRoleConvenience.java
+++ b/src/main/java/doore/member/application/convenience/TeamRoleConvenience.java
@@ -52,4 +52,9 @@ public class TeamRoleConvenience {
             throw new MemberException(CANNOT_DELETE_TEAM_LEADER, formattedMessage);
         }
     }
+
+    public void deleteAllTeamRoles(final Long memberId) {
+        final List<TeamRole> teamRoles = teamRoleRepository.findAllByMemberId(memberId);
+        teamRoleRepository.deleteAll(teamRoles);
+    }
 }

--- a/src/main/java/doore/member/domain/repository/MemberTeamRepository.java
+++ b/src/main/java/doore/member/domain/repository/MemberTeamRepository.java
@@ -1,10 +1,7 @@
 package doore.member.domain.repository;
 
 import doore.member.domain.MemberTeam;
-
 import java.util.List;
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -21,4 +18,6 @@ public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
 	void deleteByTeamIdAndMemberId(final Long teamId, final Long memberId);
 
 	Boolean existsByTeamIdAndMemberId(final Long teamId, final Long memberId);
+
+	List<MemberTeam> findAllByMemberId(final Long memberId);
 }

--- a/src/main/java/doore/member/domain/repository/ParticipantRepository.java
+++ b/src/main/java/doore/member/domain/repository/ParticipantRepository.java
@@ -10,6 +10,8 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     List<Participant> findAllByStudyId(Long studyId);
 
+    List<Participant> findAllByMemberId(Long memberId);
+
     List<Participant> findByMemberId(Long memberId);
 
     void deleteByStudyIdAndMemberId(Long studyId, Long memberId);

--- a/src/main/java/doore/member/domain/repository/StudyRoleRepository.java
+++ b/src/main/java/doore/member/domain/repository/StudyRoleRepository.java
@@ -2,6 +2,7 @@ package doore.member.domain.repository;
 
 import doore.member.domain.StudyRole;
 import doore.member.domain.StudyRoleType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,5 @@ public interface StudyRoleRepository extends JpaRepository<StudyRole, Long> {
     Long findLeaderIdByStudyId(Long studyId);
     boolean existsByStudyIdAndMemberIdAndStudyRoleType(Long studyId, Long memberId, StudyRoleType studyRoleType);
     void deleteByStudyIdAndMemberId(final Long studyId, final Long memberId);
+    List<StudyRole> findAllByMemberId(final Long memberId);
 }

--- a/src/main/java/doore/member/domain/repository/TeamRoleRepository.java
+++ b/src/main/java/doore/member/domain/repository/TeamRoleRepository.java
@@ -16,4 +16,5 @@ public interface TeamRoleRepository extends JpaRepository<TeamRole, Long> {
     List<TeamRole> findAllByTeamId(final Long teamId);
     void deleteByTeamIdAndMemberId(final Long teamId, final Long memberId);
     boolean existsByTeamIdAndMemberIdAndTeamRoleType(Long teamId, Long memberId, TeamRoleType teamRoleType);
+    List<TeamRole> findAllByMemberId(final Long memberId);
 }

--- a/src/main/java/doore/study/application/StudyCommandService.java
+++ b/src/main/java/doore/study/application/StudyCommandService.java
@@ -62,7 +62,7 @@ public class StudyCommandService {
         studyValidateAccessPermission.validateExistStudy(studyId);
 
         deleteCurriculumItemAndParticipantCurriculumItem(studyId);
-        participantConvenience.deleteAllParticipant(studyId);
+        participantConvenience.deleteAllParticipantsByStudyId(studyId);
         studyRepository.deleteById(studyId);
     }
 

--- a/src/main/java/doore/study/application/convenience/ParticipantConvenience.java
+++ b/src/main/java/doore/study/application/convenience/ParticipantConvenience.java
@@ -21,8 +21,13 @@ public class ParticipantConvenience {
                 .build());
     }
 
-    public void deleteAllParticipant(final Long studyId) {
+    public void deleteAllParticipantsByStudyId(final Long studyId) {
         final List<Participant> participants = participantRepository.findAllByStudyId(studyId);
+        participantRepository.deleteAll(participants);
+    }
+
+    public void deleteAllParticipantsByMemberId(final Long memberId) {
+        final List<Participant> participants = participantRepository.findAllByMemberId(memberId);
         participantRepository.deleteAll(participants);
     }
 

--- a/src/test/java/doore/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/doore/member/application/MemberCommandServiceTest.java
@@ -18,10 +18,12 @@ import doore.login.application.dto.response.GoogleAccountProfileResponse;
 import doore.member.application.dto.request.MyPageUpdateRequest;
 import doore.member.domain.Member;
 import doore.member.domain.MemberTeam;
+import doore.member.domain.Participant;
 import doore.member.domain.StudyRole;
 import doore.member.domain.TeamRole;
 import doore.member.domain.repository.MemberRepository;
 import doore.member.domain.repository.MemberTeamRepository;
+import doore.member.domain.repository.ParticipantRepository;
 import doore.member.domain.repository.StudyRoleRepository;
 import doore.member.domain.repository.TeamRoleRepository;
 import doore.member.exception.MemberException;
@@ -52,6 +54,8 @@ class MemberCommandServiceTest extends IntegrationTest {
     private StudyRoleRepository studyRoleRepository;
     @Autowired
     private MemberTeamRepository memberTeamRepository;
+    @Autowired
+    private ParticipantRepository participantRepository;
 
     private Member member;
     private Team team;
@@ -262,5 +266,45 @@ class MemberCommandServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> {
             memberCommandService.deleteMember(member.getId());
         }).isInstanceOf(MemberException.class).hasMessage(expectedMessage);
+    }
+
+    @Test
+    @DisplayName("[성공] 회원 탈퇴 시 팀과 스터디 관련 정보는 삭제된다.")
+    void deleteMember_회원_탈퇴_시_팀과_스터디_관련_정보는_삭제된다_성공() {
+        final Member generalMember = memberRepository.save(미나());
+
+        memberTeamRepository.save(MemberTeam.builder()
+                .member(generalMember)
+                .teamId(team.getId())
+                .build());
+        teamRoleRepository.save(TeamRole.builder()
+                .teamId(team.getId())
+                .memberId(generalMember.getId())
+                .teamRoleType(ROLE_팀원)
+                .build());
+
+        participantRepository.save(Participant.builder()
+                .studyId(study.getId())
+                .member(generalMember)
+                .build());
+        studyRoleRepository.save(StudyRole.builder()
+                .studyId(study.getId())
+                .memberId(generalMember.getId())
+                .studyRoleType(ROLE_스터디원)
+                .build());
+
+        assertThat(memberRepository.count()).isEqualTo(2);
+        assertThat(memberTeamRepository.count()).isEqualTo(2);
+        assertThat(studyRoleRepository.count()).isEqualTo(2);
+        assertThat(participantRepository.count()).isEqualTo(1);
+        assertThat(studyRoleRepository.count()).isEqualTo(2);
+
+        memberCommandService.deleteMember(generalMember.getId());
+
+        assertThat(memberRepository.count()).isEqualTo(1);
+        assertThat(memberTeamRepository.count()).isEqualTo(1);
+        assertThat(studyRoleRepository.count()).isEqualTo(1);
+        assertThat(participantRepository.count()).isEqualTo(0);
+        assertThat(studyRoleRepository.count()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #307

## 📝 작업 내용

- 팀원 탈퇴 시 팀원, 팀역할, 스터디원, 스터디역할이 삭제되도록 변경했습니다.

## 💬 리뷰 요구사항

- 테스트 설정을 setUp에 안넣은 이유는 해당 설정은 해당 테스트 메서드에서만 사용될 것 같아서 안넣었습니다.
- Optional 설정을 안한 이유는 다른 삭제 코드가 Optional 설정이 되어있지 않길래 굳이 하지 않았습니다. 만약 하는 방향으로 결정난다면 전체적으로 리팩토링 해야할 것 같습니다!
