### PR TITLE
Feature/#310 회원 탈퇴 시 학습자료 조회에 문제가 생기는 상황 해결

### DIFF
--- a/src/main/java/doore/document/application/DocumentQueryService.java
+++ b/src/main/java/doore/document/application/DocumentQueryService.java
@@ -14,7 +14,6 @@ import doore.document.exception.DocumentException;
 import doore.member.application.convenience.MemberValidateAccessPermission;
 import doore.member.application.convenience.StudyRoleValidateAccessPermission;
 import doore.member.application.convenience.TeamRoleValidateAccessPermission;
-import doore.member.domain.Member;
 import doore.study.application.convenience.StudyConvenience;
 import doore.study.domain.Study;
 import java.util.List;
@@ -68,8 +67,8 @@ public class DocumentQueryService {
                 .map(file -> new FileResponse(file.getId(), file.getName(), file.getUrl()))
                 .toList();
 
-        final Member member = memberValidateAccessPermission.getValidateExistMember(document.getUploaderId());
+        final String uploaderName = memberValidateAccessPermission.getUploaderNameByMemberId(document.getUploaderId());
 
-        return DocumentResponse.of(document, fileResponses, member.getName(), member.getId());
+        return DocumentResponse.of(document, fileResponses, uploaderName, document.getUploaderId());
     }
 }

--- a/src/main/java/doore/member/application/convenience/MemberValidateAccessPermission.java
+++ b/src/main/java/doore/member/application/convenience/MemberValidateAccessPermission.java
@@ -1,5 +1,6 @@
 package doore.member.application.convenience;
 
+import static doore.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static doore.member.exception.MemberExceptionType.UNAUTHORIZED;
 
 import doore.member.domain.Member;
@@ -21,5 +22,9 @@ public class MemberValidateAccessPermission {
 
     public Member getValidateExistMember(final Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(UNAUTHORIZED));
+    }
+
+    public String getUploaderNameByMemberId(final Long memberId) {
+        return memberRepository.findNameByIdNative(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/doore/member/domain/repository/MemberRepository.java
+++ b/src/main/java/doore/member/domain/repository/MemberRepository.java
@@ -3,8 +3,13 @@ package doore.member.domain.repository;
 import doore.member.domain.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByGoogleId(final String googleId);
+
+    @Query(value = "SELECT name FROM member WHERE id = :id", nativeQuery = true)
+    Optional<String> findNameByIdNative(@Param("id") final Long memberId);
 }

--- a/src/test/java/doore/document/application/DocumentQueryServiceTest.java
+++ b/src/test/java/doore/document/application/DocumentQueryServiceTest.java
@@ -22,6 +22,7 @@ import doore.document.domain.Document;
 import doore.document.domain.DocumentAccessType;
 import doore.document.domain.repository.DocumentRepository;
 import doore.helper.IntegrationTest;
+import doore.member.application.MemberCommandService;
 import doore.member.domain.Member;
 import doore.member.domain.StudyRole;
 import doore.member.domain.TeamRole;
@@ -48,6 +49,8 @@ public class DocumentQueryServiceTest extends IntegrationTest {
     private DocumentQueryService documentQueryService;
     @Autowired
     private DocumentCommandService documentCommandService;
+    @Autowired
+    private MemberCommandService memberCommandService;
 
     @Autowired
     private StudyRepository studyRepository;
@@ -71,6 +74,7 @@ public class DocumentQueryServiceTest extends IntegrationTest {
     private Member notParticipantMember; // 회원 + 팀원
     private StudyRole studyRole;
     private TeamRole teamRole;
+    private TeamRole otherTeamRole;
     private Team team;
 
     @BeforeEach
@@ -80,6 +84,11 @@ public class DocumentQueryServiceTest extends IntegrationTest {
         participant = memberRepository.save(아마란스());
         notMemberTeamNotParticipantMember = memberRepository.save(미나());
         notParticipantMember = memberRepository.save(아마());
+        otherTeamRole = teamRoleRepository.save(TeamRole.builder()
+                .teamRoleType(TeamRoleType.ROLE_팀원)
+                .memberId(participant.getId())
+                .teamId(study.getTeamId())
+                .build());
         teamRole = teamRoleRepository.save(TeamRole.builder()
                 .teamRoleType(TeamRoleType.ROLE_팀원)
                 .memberId(notParticipantMember.getId())
@@ -225,5 +234,49 @@ public class DocumentQueryServiceTest extends IntegrationTest {
                 documentQueryService.getDocuments(notParticipantMember.getId());
 
         assertThat(responses).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] 회원 탈퇴 시 탈퇴한 회원이 올린 학습자료의 정보는 유지된다.")
+    public void getDocument_회원_탈퇴_시_탈퇴한_회원이_올린_학습자료의_정보는_유지된다_성공() {
+        final Document otherTeamOpenTeamDocument = new DocumentFixture()
+                .groupType(TEAM)
+                .groupId(team.getId())
+                .type(URL)
+                .accessType(DocumentAccessType.TEAM)
+                .uploaderId(notParticipantMember.getId())
+                .buildDocument();
+
+        memberCommandService.deleteMember(notParticipantMember.getId());
+
+        final DocumentResponse response = documentQueryService.getDocument(otherTeamOpenTeamDocument.getId(),
+                participant.getId());
+
+        assertAll(
+                () -> assertEquals(response.title(), otherTeamOpenTeamDocument.getName()),
+                () -> assertEquals(response.description(), otherTeamOpenTeamDocument.getDescription()),
+                () -> assertEquals(response.date(), otherTeamOpenTeamDocument.getCreatedAt().toLocalDate()),
+                () -> assertEquals(response.accessType(), otherTeamOpenTeamDocument.getAccessType()),
+                () -> assertEquals(response.uploaderName(), notParticipantMember.getName()),
+                () -> assertEquals(response.uploaderMemberId(), notParticipantMember.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("[성공] 탈퇴한 회원이 있어도 학습자료는 정상적으로 조회된다.")
+    public void getAllDocuments_탈퇴한_회원이_있어도_학습자료는_정상적으로_조회된다_성공() {
+        memberCommandService.deleteMember(participant.getId());
+
+        final Page<DocumentResponse> responses =
+                documentQueryService.getAllDocument(TEAM, team.getId(), PageRequest.of(0, 4));
+
+        assertAll(
+                () -> assertThat(responses.getTotalElements()).isNotZero(),
+                () -> assertEquals(responses.getContent().get(0).title(), allOpenTeamDocument.getName()),
+                () -> assertEquals(responses.getContent().get(0).description(), allOpenTeamDocument.getDescription()),
+                () -> assertEquals(responses.getContent().get(0).date(),
+                        allOpenTeamDocument.getCreatedAt().toLocalDate()),
+                () -> assertEquals(responses.getContent().get(0).uploaderName(), participant.getName())
+        );
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close: #310

## 📝 작업 내용

- 회원 탈퇴 후 학습자료 조회가 불가한 상황을 해결했습니다.
- 원인
    - 삭제된`(is_deleted = true)` `memberId`로 멤버 이름과 `id`를 조회하려고 했기 때문
- 해결방법
    - `native query`를 이용하여 학습자료 업로더 이름 조회 시 삭제된 `member`라도 조회할 수 있도록 변경
        - `native query`에서는 파라미터 이름 매핑 자동화 기능이 안정적이지 않기 때문에 `Param`을 이용하여 직접 매핑
    - 기존 `memberId`를 보내주는 부분은 `uploaderId`와 동일하기 때문에 `uploaderId`로 변경
- 나의 학습자료 조회의 `memberId`를 수정하지 않은 이유는 탈퇴 회원은 나의 학습자료 조회를 하지 않기 때문입니다

## 💬 리뷰 요구사항

- 작업 내용 확인 부탁드려용
